### PR TITLE
Make tests pass on a machine without GPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ pytom/pytomc/sh_alignment/SpharmonicKit27/test_stability_naive
 
 # compiled docs
 doc/epydoc/
+
+# swap files
+*.swp

--- a/tests/test_IOTest.py
+++ b/tests/test_IOTest.py
@@ -22,7 +22,7 @@ class pytom_IOTest(unittest.TestCase):
             os.mkdir(self.outfolder)
 
     def tearDown(self):
-        from tests.helper_functions import remove_tree
+        from helper_functions import remove_tree
         remove_tree(self.outfolder)
 
     def read(self):
@@ -160,7 +160,7 @@ class pytom_IOTest(unittest.TestCase):
     def read_header(self):
         from pytom.agnostic.io import read_header
         header = read_header(self.fnames[1])
-        assert header
+        assert header.any()
 
     def write_rotation_angle(self):
         from pytom.agnostic.io import write_rotation_angles

--- a/tests/test_InteroplationTest.py
+++ b/tests/test_InteroplationTest.py
@@ -66,7 +66,10 @@ class pytom_InterpolationTest(unittest.TestCase):
     @unittest.skipIf(os.environ.get('AM_I_IN_A_DOCKER_CONTAINER', False),
                      "The test below uses a GPU and cannot execute in a docker environment")
     def test_voltools_gpu(self):
-        import cupy as cp
+        try:
+            import cupy as cp
+        except ImportError:
+            raise unittest.SkipTest("No working cupy install found.")
         box = cp.zeros(self.dims, dtype=cp.float32)
         box[self.point[0], self.point[1], self.point[2]] = 1.
 


### PR DESCRIPTION
This makes it so that the tests pass on my own desktop (without GPU) and some small admin cleanup

- It adds `*.swp` to `.gitignore` to prevent `vim` lock files from being committed.
- Fixes 2 offending tests in `tests_IOTest.py`:
  -  one mangled import 
  -  one where numpy was complaining that an assertion on an array is ambigious (I assumed anything non-zero is fine for that test, the code that it is testing (`read_header`) should raise a numpy error if the file can't be read) 
- skip a unittest depending on cupy if it can't be imported (like on a machine without gpu)