### PR TITLE
Remove path source

### DIFF
--- a/pytom/__init__.py
+++ b/pytom/__init__.py
@@ -6,10 +6,10 @@ __all__ = ["alignment", "angles", "basic", "bin", "classification", "gui", "gpu"
 __version__ = "1.0"
 
 try:
-    import pytom_volume
-    import pytom_numpy
-    import pytom_mpi
-    import pytom_freqweight
-    import pytom_fftplan
+    import pytom.lib.pytom_volume as pytom_volume
+    import pytom.lib.pytom_numpy as pytom_numpy
+    import pytom.lib.pytom_mpi as pytom_mpi
+    import pytom.lib.pytom_freqweight as pytom_freqweight
+    import pytom.lib.pytom_fftplan as pytom_fftplan
 except (ModuleNotFoundError, ImportError):
     print('The C-functionality of PyTom failed to load. For full functionality, please run pytom or ipytom.')

--- a/pytom/agnostic/io.py
+++ b/pytom/agnostic/io.py
@@ -2011,7 +2011,7 @@ def write(filename, data, tilt_angle=0, pixel_size=1, order='F', fmt=None, heade
 
     """
     import os
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
 
     # Define the allowed file formats and related write function.
     write_functions = {'em': write_em,
@@ -2027,7 +2027,7 @@ def write(filename, data, tilt_angle=0, pixel_size=1, order='F', fmt=None, heade
 
     # If data is instance of vol datatype, convert data to numpy array. Needed because header is defined differently.
     if isinstance(data, vol):
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
         try:
             data_npy = vol2npy(data).copy()
             # Write data to file, using respective write function
@@ -2244,8 +2244,8 @@ def n2v(data):
     @param data: data to convert.
     """
     try:
-        from pytom_volume import vol
-        from pytom_numpy import npy2vol
+        from pytom.lib.pytom_volume import vol
+        from pytom.lib.pytom_numpy import npy2vol
     except:
         raise ImportError("Pytom library is not installed or set properly!")
 

--- a/pytom/angles/angleFnc.py
+++ b/pytom/angles/angleFnc.py
@@ -121,7 +121,7 @@ def matToZXZ(rotMatrix,inRad=False):
     @return: [z1,z2,x] 
     @author: Friedrich Forster
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     import math
     from pytom.basic.structures import Rotation
     from pytom.angles.angle import rad2deg

--- a/pytom/angles/globalSampling.py
+++ b/pytom/angles/globalSampling.py
@@ -70,7 +70,7 @@ class GlobalSampling(AngleObject):
         self._angleList = [] 
         
         if not filename == '':
-            import pytom_volume
+            import pytom.lib.pytom_volume as pytom_volume
             from pytom.angles.angle import rad2deg
             
             try:

--- a/pytom/basic/correlation.py
+++ b/pytom/basic/correlation.py
@@ -2,18 +2,18 @@ def xcc(volume,template,mask=None, volumeIsNormalized=False):
     """
     xcc: Calculates the cross correlation coefficient in real space
     @param volume: A volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param template: A template that is searched in volume. Must be of same size as volume.
-    @type template:  L{pytom_volume.vol}
+    @type template:  L{pytom.lib.pytom_volume.vol}
     @param mask: mask to constrain correlation
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param volumeIsNormalized: only used for compatibility with nxcc - not used
     @type volumeIsNormalized: L{bool}
     @return: A unscaled value
     @raise exception: Raises a runtime error if volume and template have a different size.  
     @author: Thomas Hrabe 
     """
-    from pytom_volume import sum
+    from pytom.lib.pytom_volume import sum
     from pytom.tools.macros import volumesSameSize
     
     if not volumesSameSize(volume,template):
@@ -34,11 +34,11 @@ def nxcc(volume, template, mask=None, volumeIsNormalized=False):
     """
     nxcc: Calculates the normalized cross correlation coefficient in real space
     @param volume: A volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param template: A template that is searched in volume. Must be of same size as volume.
-    @type template:  L{pytom_volume.vol}
+    @type template:  L{pytom.lib.pytom_volume.vol}
     @param mask: mask to constrain correlation
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param volumeIsNormalized: speed up if volume is already normalized
     @type volumeIsNormalized: L{bool}
     @return: A value between -1 and 1
@@ -47,7 +47,7 @@ def nxcc(volume, template, mask=None, volumeIsNormalized=False):
     @change: flag for pre-normalized volume, FF
     """
 
-    from pytom_volume import vol,sum,limit
+    from pytom.lib.pytom_volume import vol,sum,limit
     from pytom.tools.macros import volumesSameSize
     
     if not volumesSameSize(volume,template):
@@ -61,7 +61,7 @@ def nxcc(volume, template, mask=None, volumeIsNormalized=False):
         p = volume.numelem()
         result = v*t
     else:
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
         from pytom.basic.normalise import normaliseUnderMask
         if not volumeIsNormalized:
             (v,p) = normaliseUnderMask(volume, mask)
@@ -85,17 +85,17 @@ def xcf(volume, template, mask=None, stdV=None):
     result is scaled only by the square of the number of elements.
 
     @param volume : The search volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param template : The template searched (this one will be used for conjugate complex multiplication)
-    @type template: L{pytom_volume.vol}
+    @type template: L{pytom.lib.pytom_volume.vol}
     @param mask: changed: will be used if specified
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param stdV: Will be unused, only for compatibility reasons with FLCF 
     @return: XCF volume
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     @author: Thomas Hrabe
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     from pytom.basic import fourier
 
     if mask != None:
@@ -141,12 +141,12 @@ def nXcf(volume,template,mask=None, stdV=None):
 
     @param volume: The search volume
     @param template: The template searched (this one will be used for conjugate complex multiplication)
-    @type template: L{pytom_volume.vol}
+    @type template: L{pytom.lib.pytom_volume.vol}
     @param mask: template mask. If not given, a default sphere mask will be generated which has the same size with the given template.
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param stdV: Will be unused, only for compatibility reasons with FLCF
     @return: the calculated nXcf volume
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     @author: Thomas Hrabe
     @change: masking of template implemented
     """
@@ -169,16 +169,16 @@ def meanValueUnderMask(volume, mask=None, p=None):
     """
     meanValueUnderMask: Determines the mean value under a mask
     @param volume: The volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param mask:  The mask
-    @type mask:  L{pytom_volume.vol}
+    @type mask:  L{pytom.lib.pytom_volume.vol}
     @param p: precomputed number of voxels in mask
     @type p: float
     @return: A value (scalar)
     @rtype: single
     @change: support None as mask, FF 08.07.2014
     """
-    from pytom_volume import vol, sum
+    from pytom.lib.pytom_volume import vol, sum
   
     if not volume.__class__ == vol:
         raise TypeError("meanValueUnderMask: Volume parameter must be of type vol!")
@@ -198,17 +198,17 @@ def stdValueUnderMask(volume, mask, meanValue, p=None):
     stdValueUnderMask: Determines the std value under a mask
 
     @param volume: input volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param mask: mask
-    @type mask:  L{pytom_volume.vol}
+    @type mask:  L{pytom.lib.pytom_volume.vol}
     @param p: non zero value numbers in the mask
     @type p: L{float} or L{int}
     @return: A value
     @rtype: L{float}
     @change: support None as mask, FF 08.07.2014
     """
-    from pytom_volume import sum
-    from pytom_volume import vol, power, variance
+    from pytom.lib.pytom_volume import sum
+    from pytom.lib.pytom_volume import vol, power, variance
     
     assert volume.__class__ == vol
     if mask:
@@ -236,19 +236,19 @@ def meanUnderMask(volume, mask, p):
     """
     meanUnderMask: calculate the mean volume under the given mask (Both should have the same size)
     @param volume: input volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param mask: mask
-    @type mask:  L{pytom_volume.vol}
+    @type mask:  L{pytom.lib.pytom_volume.vol}
     @param p: non zero value numbers in the mask
     @type p: L{int} or L{float}
     @return: the calculated mean volume under mask
-    @rtype:  L{pytom_volume.vol}
+    @rtype:  L{pytom.lib.pytom_volume.vol}
     @author: Yuxiang Chen
     """
     size = volume.numelem()
     
     from pytom.basic.fourier import fft, ifft, iftshift
-    from pytom_volume import conjugate
+    from pytom.lib.pytom_volume import conjugate
     # for some reason, this has to be conjugated. (Otherwise the asym mask won't work)
     fMask = fft(mask)
     conjugate(fMask)
@@ -261,19 +261,19 @@ def stdUnderMask(volume, mask, p, meanV):
     """
     stdUnderMask: calculate the std volume under the given mask
     @param volume: input volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param mask: mask
-    @type mask:  L{pytom_volume.vol}
+    @type mask:  L{pytom.lib.pytom_volume.vol}
     @param p: non zero value numbers in the mask
     @type p: L{int}
     @param meanV: mean volume under mask, which should already been caculated
-    @type meanV:  L{pytom_volume.vol}
+    @type meanV:  L{pytom.lib.pytom_volume.vol}
     @return: the calculated std volume under mask
-    @rtype:  L{pytom_volume.vol}
+    @rtype:  L{pytom.lib.pytom_volume.vol}
     @author: Yuxiang Chen
     """
     from pytom.basic.fourier import fft, ifft, iftshift
-    from pytom_volume import vol, power, limit
+    from pytom.lib.pytom_volume import vol, power, limit
     
     copyV = vol(volume.sizeX(), volume.sizeY(), volume.sizeZ())
     copyV.copyVolume(volume)
@@ -285,7 +285,7 @@ def stdUnderMask(volume, mask, p, meanV):
 
     result = meanUnderMask(copyV, mask, p) - copyMean
 
-    # from pytom_volume import abs
+    # from pytom.lib.pytom_volume import abs
     # abs(result)
     limit(result, 1e-09, 1, 0, 0, True, False)  # this step is needed to set all those value (close to 0) to 1
     power(result, 0.5)
@@ -299,24 +299,22 @@ def FLCF(volume, template, mask=None, stdV=None, wedge=1):
     This functions works only when the mask is in the middle.
     
     @param volume: target volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param template: template to be searched. It can have smaller size then target volume.
-    @type template: L{pytom_volume.vol}
+    @type template: L{pytom.lib.pytom_volume.vol}
     @param mask: template mask. If not given, a default sphere mask will be generated which has the same size with the given template.
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param stdV: standard deviation of the target volume under mask, which do not need to be calculated again when the mask is identical.
-    @type stdV: L{pytom_volume.vol}
+    @type stdV: L{pytom.lib.pytom_volume.vol}
     @return: the local correlation function
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     
     @author: Yuxiang Chen
     '''
-    from pytom_volume import vol, pasteCenter
+    from pytom.lib.pytom_volume import vol, pasteCenter, conjugate, sum
     from pytom.basic.files import read
     from pytom.basic.fourier import fft, ifft, iftshift
-    from pytom_volume import conjugate
     from pytom.basic.structures import Mask
-    from pytom_volume import sum
     from pytom.basic.files import write_em
 
     if volume.__class__ != vol and template.__class__ != vol:
@@ -327,7 +325,7 @@ def FLCF(volume, template, mask=None, stdV=None, wedge=1):
 
     # generate the mask 
     if mask.__class__ != vol:
-        from pytom_volume import initSphere
+        from pytom.lib.pytom_volume import initSphere
         mask = vol(template.sizeX(), template.sizeY(), template.sizeZ())
         mask.setAll(0)
         initSphere(mask, template.sizeX()/2,0,0,template.sizeX()/2, template.sizeY()/2, template.sizeZ()/2)
@@ -377,16 +375,16 @@ def bandCC(volume,reference,band,verbose = False):
     """
     bandCC: Determines the normalised correlation coefficient within a band
     @param volume: The volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param reference: The reference
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param band: [a,b] - specify the lower and upper end of band.
     @return: First parameter - The correlation of the two volumes in the specified band. 
              Second parameter - The bandpass filter used.
-    @rtype: List - [float,L{pytom_freqweight.weight}]
+    @rtype: List - [float,L{pytom.lib.pytom_freqweight.weight}]
     @author: Thomas Hrabe    
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     from pytom.basic.filter import bandpassFilter
     from pytom.basic.correlation import xcf
     from math import sqrt
@@ -439,19 +437,19 @@ def weightedXCC(volume,reference,numberOfBands,wedgeAngle=-1):
         """
         weightedXCC: Determines the band weighted correlation coefficient for a volume and reference. Notation according Steward/Grigorieff paper
         @param volume: A volume
-        @type volume: L{pytom_volume.vol}
+        @type volume: L{pytom.lib.pytom_volume.vol}
         @param reference: A reference of same size as volume
-        @type reference: L{pytom_volume.vol}
+        @type reference: L{pytom.lib.pytom_volume.vol}
         @param numberOfBands: Number of bands
         @param wedgeAngle: A optional wedge angle
         @return: The weighted correlation coefficient
         @rtype: float  
         @author: Thomas Hrabe   
         """    
-        import pytom_volume
+        import pytom.lib.pytom_volume as pytom_volume
         from pytom.basic.fourier import fft
         from math import sqrt
-        import pytom_freqweight
+        import pytom.lib.pytom_freqweight as pytom_freqweight
         result = 0
         numberVoxels = 0
         
@@ -518,9 +516,9 @@ def FSCSum(volume,reference,numberOfBands,wedgeAngle=-1):
     """
     FSCSum: Determines the sum of the Fourier Shell Correlation coefficient for a volume and reference. 
     @param volume: A volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param reference: A reference of same size as volume
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param numberOfBands: Number of bands
     @param wedgeAngle: A optional wedge angle
     @return: The sum FSC coefficient
@@ -529,10 +527,10 @@ def FSCSum(volume,reference,numberOfBands,wedgeAngle=-1):
     """    
     
     from pytom.basic.correlation import bandCC
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     from pytom.basic.fourier import fft
     from math import sqrt
-    import pytom_freqweight
+    import pytom.lib.pytom_freqweight as pytom_freqweight
     result = 0
     numberVoxels = 0
     
@@ -568,11 +566,11 @@ def bandCF(volume,reference,band=[0,100]):
     @param band: [a,b] - specify the lower and upper end of band. [0,1] if not set.
     @return: First parameter - The correlation of the two volumes in the specified ring. 
              Second parameter - The bandpass filter used.
-    @rtype: List - [L{pytom_volume.vol},L{pytom_freqweight.weight}]
+    @rtype: List - [L{pytom.lib.pytom_volume.vol},L{pytom.lib.pytom_freqweight.weight}]
     @author: Thomas Hrabe   
     @todo: does not work yet -> test is disabled
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     from math import sqrt
     from pytom.basic import fourier
     from pytom.basic.filter import bandpassFilter
@@ -620,15 +618,15 @@ def weightedXCF(volume,reference,numberOfBands,wedgeAngle=-1):
     @param numberOfBands:Number of bands
     @param wedgeAngle: A optional wedge angle
     @return: The weighted correlation function 
-    @rtype: L{pytom_volume.vol} 
+    @rtype: L{pytom.lib.pytom_volume.vol} 
     @author: Thomas Hrabe 
     @todo: does not work yet -> test is disabled
     """
     from pytom.basic.correlation import bandCF
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     from math import sqrt
-    import pytom_freqweight
-    
+    import pytom.lib.pytom_freqweight as pytom_freqweight
+
     result = pytom_volume.vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
     result.setAll(0)
     cc2 = pytom_volume.vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
@@ -692,9 +690,9 @@ def FSC(volume1,volume2,numberBands,mask=None,verbose=False, filename=None):
     """
     FSC - Calculates the Fourier Shell Correlation for two volumes
     @param volume1: volume one
-    @type volume1: L{pytom_volume.vol}
+    @type volume1: L{pytom.lib.pytom_volume.vol}
     @param volume2: volume two
-    @type volume2: L{pytom_volume.vol}
+    @type volume2: L{pytom.lib.pytom_volume.vol}
     @param numberBands: number of shells for FSC
     @type numberBands: int
     @param filename: write FSC to ascii file if specified
@@ -708,7 +706,7 @@ def FSC(volume1,volume2,numberBands,mask=None,verbose=False, filename=None):
     from pytom.basic.correlation import bandCC
     from pytom.tools.macros import volumesSameSize
     from pytom.basic.structures import Mask
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     
     if not volumesSameSize(volume1, volume2):
         raise RuntimeError('Volumes must have the same size!')
@@ -819,9 +817,9 @@ def soc(volume,reference,mask=None, stdV=None):
     """
     soc : Second Order Correlation. Correlation of correlation peaks.
     @param volume: The volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param reference: The reference / template
-    @type reference:  L{pytom_volume.vol}
+    @type reference:  L{pytom.lib.pytom_volume.vol}
     @author: Thomas Hrabe   
     """
     referencePeak = FLCF(reference,reference,mask)
@@ -839,7 +837,7 @@ def subPixelPeakParabolic(scoreVolume, coordinates, verbose=False):
     @type verbose: bool
     @return: Returns [peakValue,peakCoordinates] with sub pixel accuracy
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     assert type(scoreVolume) == vol, "scoreVolume must be vol!"
     if (coordinates[0] == 0 or coordinates[0] == scoreVolume.sizeX()-1 or
                 coordinates[1] == 0 or coordinates[1] == scoreVolume.sizeY()-1 or
@@ -913,7 +911,7 @@ def subPixelPeak(scoreVolume, coordinates, cubeLength=8, interpolation='Spline',
     if (interpolation.lower() == 'quadratic') or (interpolation.lower() == 'parabolic'):
         (peakValue,peakCoordinates) = subPixelPeakParabolic(scoreVolume=scoreVolume, coordinates=coordinates, verbose=verbose)
         return [peakValue,peakCoordinates]
-    from pytom_volume import vol,subvolume,rescaleSpline,peak
+    from pytom.lib.pytom_volume import vol,subvolume,rescaleSpline,peak
     from pytom.basic.transformations import resize
   
     #extend function for 2D
@@ -987,18 +985,18 @@ def dev(volume, template, mask=None, volumeIsNormalized=False):
     """
     dev: Calculates the squared deviation of volume and template in real space
     @param volume: A volume
-    @type volume:  L{pytom_volume.vol}
+    @type volume:  L{pytom.lib.pytom_volume.vol}
     @param template: A template that is searched in volume. Must be of same size as volume.
-    @type template:  L{pytom_volume.vol}
+    @type template:  L{pytom.lib.pytom_volume.vol}
     @param mask: mask to constrain correlation
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param volumeIsNormalized: speed up if volume is already normalized
     @type volumeIsNormalized: L{bool}
     @return: deviation
     @raise exception: Raises a runtime error if volume and template have a different size.
     @author: FF
     """
-    from pytom_volume import vol,sum
+    from pytom.lib.pytom_volume import vol,sum
     from pytom.tools.macros import volumesSameSize
 
     assert type(volume) == vol, "dev: volume has to be of type vol!"

--- a/pytom/basic/files.py
+++ b/pytom/basic/files.py
@@ -20,7 +20,7 @@ def readProxy(fileName, subregion1=0, subregion2=0, subregion3=0,
               subregion4=0, subregion5=0, subregion6=0, sampling1=0,
               sampling2=0, sampling3=0, binning1=0, binning2=0, binning3=0):
     """
-    readProxy: Proxy function to easily replace pytom_volume calls with read \
+    readProxy: Proxy function to easily replace pytom.lib.pytom_volume calls with read \
     function below
     """
 
@@ -46,11 +46,11 @@ def read(file, subregion=[0, 0, 0, 0, 0, 0], sampling=[0, 0, 0], binning=[0, 0, 
     2 will bin with a kernelsize of 2 pixels along each dimension, 3 will bin
     with a kernelsize of 3 pixels along each dimension and so forth.
     @type binning:  List of 3 integers
-    @return: A volume object. L{pytom_volume.vol}
+    @return: A volume object. L{pytom.lib.pytom_volume.vol}
     @author: Thomas Hrabe
     """
     from pytom.tools.files import checkFileExists
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
 
     if not isinstance(file, str):
         raise TypeError('File parameter must be a string!')
@@ -90,7 +90,7 @@ def readSubvolumeFromFourierspaceFile(filename, sizeX, sizeY, sizeZ):
     @return: A subvolume
     @author: Thomas Hrabe
     """
-    from pytom_volume import vol, subvolume, paste
+    from pytom.lib.pytom_volume import vol, subvolume, paste
     from pytom.basic.fourier import fourierSizeOperation
     [newX, newY, newZ] = fourierSizeOperation(sizeX, sizeY, sizeZ,
                                               reducedToFull=False)
@@ -325,7 +325,7 @@ def atomList2em(atomList, pixelSize, cubeSize, densityNegative=False):
     @return:
     """
     from math import floor
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
 
     if len(atomList) == 0:
         raise RuntimeError('atomList2em : Your atom list is empty!')
@@ -408,7 +408,7 @@ def recenterVolume(volume, densityNegative=False):
     from pytom.agnostic.io import read, write
     from pytom.agnostic.tools import paste_in_center
     from pytom.gpu.initialize import xp
-    from pytom_numpy import vol2npy
+    from pytom.lib.pytom_numpy import vol2npy
     import os
 
     try:
@@ -455,7 +455,7 @@ def initSphere(cubeSize, radius, smoothing=0, centerX=None, centerY=None, center
     @param centerY: Center of shpere along Y axis
     @param centerZ: Center of shpere along Z axis
     """
-    from pytom_volume import vol, initSphere
+    from pytom.lib.pytom_volume import vol, initSphere
 
     sphere = vol(cubeSize, cubeSize, cubeSize)
     sphere.setAll(0)
@@ -482,7 +482,7 @@ def cutParticlesFromTomogram(particleList, cubeSize, sourceTomogram, coordinateB
     @param cubeSize: Size of cut out cubes
     @type cubeSize: int
     @param sourceTomogram: The source tomogram (either file name or volume).
-    @type sourceTomogram: L{str} or L{pytom_volume.vol}
+    @type sourceTomogram: L{str} or L{pytom.lib.pytom_volume.vol}
     @param coordinateBinning: binning factor affecting coordinates. was template matching processed on binned data? use fractions (1/2 , 1/4) if tomogram is binned and coordinates are from unbinned...
     @param binningFactorOut: binning factor for final cubes
     @author: Thomas Hrabe
@@ -496,7 +496,7 @@ def cutParticlesFromTomogram(particleList, cubeSize, sourceTomogram, coordinateB
         raise RuntimeError(
             'The destination directory ' + destinationDirectory + ' does not exist. Create directory first.')
 
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
 
     cubeRadius = cubeSize / 2
 
@@ -768,7 +768,7 @@ def read_em(filename, binning=None):
     @type binning: 3-dim array
     @return: [data, header]
     """
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
 
     # read the header
     header = read_em_header(filename)
@@ -795,7 +795,7 @@ def write_em(filename, data, header=None):
     @param filename: filename
     @type filename: str
     @param data: volume data
-    @type data: pytom_volume.vol
+    @type data: pytom.lib.pytom_volume.vol
     @param header: em header
     @type header: EMHeader
     """
@@ -879,7 +879,7 @@ def mdoc2meta(filename, target, prefix=None, outname=''):
     numpy.savetxt(newFilename, metadata, fmt=fmt, header=header)
 
 def ccp42em(filename, target, prefix='sorted_', outname=None):
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
     from pytom.tools.files import checkFileExists, checkDirExists
     import os
 
@@ -896,7 +896,7 @@ def ccp42em(filename, target, prefix='sorted_', outname=None):
     emfile.write(newFilename, 'em')
 
 def ccp42mrc(filename, target, prefix='sorted_', outname=None):
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
     from pytom.tools.files import checkFileExists, checkDirExists
     import os
 
@@ -931,7 +931,7 @@ def em2mrc(filename, target, prefix='sorted_', outname=None):
     write(newFilename, data, tilt_angle=tilt_angle)
 
 def em2ccp4(filename, target, prefix='sorted_', outname=None):
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
     from pytom.tools.files import checkFileExists, checkDirExists
     import os
 
@@ -948,7 +948,7 @@ def em2ccp4(filename, target, prefix='sorted_', outname=None):
     emfile.write(newFilename, 'ccp4')
 
 def mrc2ccp4(filename, target, prefix='sorted_', outname=None):
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
     from pytom.tools.files import checkFileExists, checkDirExists
     import os
 
@@ -1011,7 +1011,7 @@ def pdb2em(filename, target, prefix='', pixelSize=1, cubeSize=200, chain=None, i
     @author: Thomas Hrabe & Luis Kuhn
     """
     from math import floor
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
 
     pdbPath = filename
 
@@ -1042,7 +1042,7 @@ def pdb2mrc(pdbPath, pixelSize=1, cubeSize=200, chain=None, invertDensity=False,
 
     if fname:
         from pytom.agnostic.io import write as writeNPY
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
 
         writeNPY(fname, vol2npy(vol))
 
@@ -1059,7 +1059,7 @@ def mmCIF2em(mmCIFPath, pixelSize=1, cubeSize=200, chain=None, densityNegative=F
     @author: Thomas Hrabe
     """
     from math import floor
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
 
     atomList = mmCIFParser(mmCIFPath, chain)
 
@@ -1084,7 +1084,7 @@ def mmCIF2mrc(mmCIFPath, pixelSize=1, cubeSize=200, chain=None, densityNegative=
     @author: Thomas Hrabe
     """
     from math import floor
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
 
     atomList = mmCIFParser(mmCIFPath, chain)
 
@@ -1095,7 +1095,7 @@ def mmCIF2mrc(mmCIFPath, pixelSize=1, cubeSize=200, chain=None, densityNegative=
 
     if fname:
         from pytom.agnostic.io import write as writeNPY
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
 
         writeNPY(fname, vol2npy(vol))
 

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pytom.basic.fourier import radialaverage, ftshift, iftshift
-from pytom_volume import reducedToFull, fullToReduced, vol, max
+from pytom.lib.pytom_volume import reducedToFull, fullToReduced, vol, max
 from math import sqrt
 
 
@@ -11,17 +11,17 @@ def profile2FourierVol( profile, dim=None, reduced=False):
     for sampling.
 
     @param profile: profile
-    @type profile: 1-d L{pytom_volume.vol} or 1-d python array
+    @type profile: 1-d L{pytom.lib.pytom_volume.vol} or 1-d python array
     @param dim: dimension of (cubic) output
     @type dim: L{int}
     @param reduced: If true reduced Fourier representation (N/2+1, N, N) is generated.
     @type reduced: L{bool}
 
     @return: 3-dim complex volume with spherically symmetrical profile
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from math import sqrt
 
     if not dim:
@@ -86,11 +86,11 @@ def filter_volume_by_profile( volume, profile):
     """
     filter volume by 1-d profile
     @param volume: volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param profile: 1-d profile
-    @type profile: L{pytom_volume.vol}
+    @type profile: L{pytom.lib.pytom_volume.vol}
     @return: outvol
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
     from pytom.basic.filter import profile2FourierVol
@@ -108,9 +108,9 @@ def gridCTF(x_array, y_array, z_array):
     @type y_array: 1-dim array
     @type z_array: 1-dim array
     @return: 3-dim volumes with x, y, z values in x,y,z dimension, respectively
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     
     cubeSizeX = len(x_array)  
     cubeSizeY = len(y_array) 
@@ -152,9 +152,9 @@ def volCTF(defocus, x_dim, y_dim, z_dim, pixel_size=None, voltage=None, Cs=None,
     @param y_dim: dimension of volume in y
     @param z_dim: dimension of volume in z
     @return: 3-dim volumes with x, y, z values in x,y,z dimension, respectively
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     """
-    from pytom_volume import vol, power
+    from pytom.lib.pytom_volume import vol, power
     from pytom.tools.macros import frange
     import math
     
@@ -215,17 +215,17 @@ def convolutionCTF(volume, defocus, pixelSize=None, voltage=None, Cs=None, sigma
     """
     convolutionCTF:
     @param volume: input volume to be convolved with CTF
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param defocus: Negative value = underfocus (in microns)
     @param pixelSize: Size of pixels / voxels (in Anstroms)
     @param voltage: 
     @param Cs:
     @param sigma: 
     @return: CTF filtered volume
-    @rtype L{pytom_volume.vol}
+    @rtype L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
-    from pytom_volume import subvolume, complexRealMult
+    from pytom.lib.pytom_volume import subvolume, complexRealMult
     from pytom.basic.fourier import ftshift, fft, ifft
     from pytom.basic.filter import volCTF
     
@@ -245,7 +245,7 @@ def fourierFilterShift(filter):
     fourierFilterShift: NEEDS Documentation
     @param filter: NEEDS Documentation 
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     
     widthX = filter.sizeX()
     centerX = filter.sizeX()//2
@@ -273,7 +273,7 @@ def fourierFilterShift_ReducedComplex(filter):
     fourierFilterShift: NEEDS Documentation
     @param filter: NEEDS Documentation
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
 
     widthX = filter.sizeX()
     centerX = filter.sizeX()//2
@@ -303,7 +303,7 @@ def circleFilter(sizeX,sizeY, radiusCutoff):
     @param sizeY: NEEDS Documentation
     @param radiusCutoff: NEEDS Documentation
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     
     centerX = sizeX//2
         
@@ -333,7 +333,7 @@ def rampFilter( sizeX, sizeY, crowtherFreq=None, N=None):
     @return: filter volume
     
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from math import exp
 
     centerX = sizeX//2
@@ -372,9 +372,9 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     @return: filter volume
 
     """
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from pytom.basic.files import read
-    from pytom_numpy import npy2vol
+    from pytom.lib.pytom_numpy import npy2vol
     from numpy import array, matrix, sin, pi, arange, float32, column_stack, argmin, clip, ones, ceil
 
 
@@ -422,9 +422,9 @@ def rotateFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     """
     from numpy import zeros_like, ones, column_stack, sin, abs, zeros, pi, ceil, floor, float32, array
     from scipy.ndimage import rotate
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from pytom.basic.files import read
-    from pytom_numpy import npy2vol
+    from pytom.lib.pytom_numpy import npy2vol
 
     tilt_angles = array(tilt_angles)
 
@@ -470,7 +470,7 @@ def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, retu
     """
     rotateWeighting: Rotates a frequency weighting volume around the center. If the volume provided is reduced complex, it will be rescaled to full size, ftshifted, rotated, iftshifted and scaled back to reduced size.
     @param weighting: A weighting volume
-    @type weighting: L{pytom_volume.vol}
+    @type weighting: L{pytom.lib.pytom_volume.vol}
     @param z1: Z1 rotation angle
     @type z1: float
     @param z2: Z2 rotation angle
@@ -479,7 +479,7 @@ def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, retu
     @type x: float
     @param mask:=None is there a rotation mask? A mask with all = 1 will be generated otherwise. Such mask should be \
         provided anyway.
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param isReducedComplex: Either set to True or False. Will be determined otherwise
     @type isReducedComplex: bool
     @param returnReducedComplex: Return as reduced complex? (Default is False)
@@ -487,18 +487,17 @@ def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, retu
     @param binarize: binarize weighting
     @type binarize: bool
     @return: weight as reduced complex volume
-    @rtype: L{pytom_volume.vol_comp}
+    @rtype: L{pytom.lib.pytom_volume.vol_comp}
     """
-    from pytom_volume import vol, limit, vol_comp
-    from pytom_volume import rotate
+    from pytom.lib.pytom_volume import vol, limit, vol_comp, rotate
     assert type(weighting) == vol or  type(weighting) == vol_comp, "rotateWeighting: input neither vol nor vol_comp"
     
     isReducedComplex = isReducedComplex or int(weighting.sizeX()/2)+1 == weighting.sizeZ();
 
     if isReducedComplex:
         #scale weighting to full size
-        from pytom_fftplan import fftShift
-        from pytom_volume import reducedToFull
+        from pytom.lib.pytom_fftplan import fftShift
+        from pytom.lib.pytom_volume import reducedToFull
         weighting = reducedToFull(weighting)
         fftShift(weighting, True)
 
@@ -512,8 +511,8 @@ def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, retu
     weightingRotated = weightingRotated * mask
     
     if returnReducedComplex:
-        from pytom_fftplan import fftShift
-        from pytom_volume import fullToReduced
+        from pytom.lib.pytom_fftplan import fftShift
+        from pytom.lib.pytom_volume import fullToReduced
         fftShift(weightingRotated,True)
         returnVolume = fullToReduced(weightingRotated)
     else:
@@ -528,7 +527,7 @@ def wedgeFilter(volume,angle,radius=0,angleIsHalf=True,fourierOnly=False):
     """
     wedgeFilter: performs a single wedge filtering of volume.
     @param volume: The volume filtered.
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param angle: Opening angle of the wedge.
     @type angle: C{float}
     @param radius: cutoff radius (means lowpass filter radius - 0 by default)
@@ -537,7 +536,7 @@ def wedgeFilter(volume,angle,radius=0,angleIsHalf=True,fourierOnly=False):
     @return: The wedge filtered volume,the filter and the filtered volume in fourier space  
     @author: Thomas Hrabe
     """
-    import pytom_freqweight
+    import pytom.lib.pytom_freqweight as pytom_freqweight
     
     if angle <= 0:
         return volume
@@ -554,7 +553,7 @@ def bandpassFilter(volume, lowestFrequency, highestFrequency, bpf=None, smooth=0
     """
     bandpassFilter: Performs bandpass filtering of volume.
     @param volume: The volume to be filtered
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param lowestFrequency: The lowest frequency in the filter as absolute pixel value
     @type lowestFrequency: L{float}
     @param highestFrequency: The highest frequency in the filter as absolute pixel value
@@ -565,8 +564,8 @@ def bandpassFilter(volume, lowestFrequency, highestFrequency, bpf=None, smooth=0
     @author: Thomas Hrabe
     """
 
-    import pytom_freqweight
-    import pytom_volume
+    import pytom.lib.pytom_freqweight as pytom_freqweight
+    import pytom.lib.pytom_volume as pytom_volume
     
     if volume.__class__ == pytom_volume.vol:
         from pytom.basic.fourier import fft
@@ -584,15 +583,15 @@ def lowpassFilter(volume,band,smooth=0,fourierOnly=False):
     """
     lowpassFilter: 
     @param volume: The volume filtered
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param band: Upper end of band(in pixels)
     @param smooth: Adjusts the size of gaussian falloff around each band end.
     @return: The lowpass filtered volume,the filter and the filtered volume in fourier space
     @author: Thomas Hrabe 
     """
         
-    import pytom_freqweight
-    import pytom_volume
+    import pytom.lib.pytom_freqweight as pytom_freqweight
+    import pytom.lib.pytom_volume as pytom_volume
     
     if volume.__class__ == pytom_volume.vol:
         from pytom.basic.fourier import fft
@@ -608,14 +607,14 @@ def highpassFilter(volume,band,smooth=0,fourierOnly=False):
     """
     highpassFilter:
     @param volume:  The volume filtered
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param band: Lower end of band (in pixels)
     @param smooth: Adjusts the size of gaussian falloff around each band end.
     @return: The highpass filtered volume,the filter and the filtered volume in fourier space
     @author: Thomas Hrabe 
     """
-    import pytom_freqweight
-    import pytom_volume
+    import pytom.lib.pytom_freqweight as pytom_freqweight
+    import pytom.lib.pytom_volume as pytom_volume
     
     if volume.__class__ == pytom_volume.vol:
         from pytom.basic.fourier import fft
@@ -631,14 +630,14 @@ def filter(volume,filterObject,fourierOnly=False):
     """
     filter: A generic filter method.
     @param volume: The volume to be filtered
-    @type volume: L{pytom_volume.vol}
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param filterObject: A filter object (either wedgeFilter, bandpassFilter, ...)
     @return: The filtered volume,the filter and the filtered volume in fourier space
     @author: Thomas Hrabe
     """
     from pytom.basic.fourier import fft, ifft
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     
     if volume.__class__ == pytom_volume.vol:
         fvolume = fft(volume)
@@ -663,14 +662,14 @@ def filter(volume,filterObject,fourierOnly=False):
 def gaussian_filter(vol, sigma):
     """
     @param vol: input volume
-    @type vol: L{pytom_volume.vol}
+    @type vol: L{pytom.lib.pytom_volume.vol}
     @param sigma: xxx
     @type sigma: xxx
     @return: resulting volume
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     """
     import numpy as np
-    from pytom_numpy import vol2npy, npy2vol
+    from pytom.lib.pytom_numpy import vol2npy, npy2vol
     from scipy.ndimage.filters import gaussian_filter
     v = vol2npy(vol)
     r = gaussian_filter(v, sigma)
@@ -685,13 +684,13 @@ def wiener_filter(fsc, even_ctf_sum, odd_ctf_sum, fudge=1):
     @param fsc: fsc curve of even and odd averages
     @type fsc: L{list}
     @param even_ctf_sum: even ctf sum volume, normalized over the number of particles in the half set, reduced complex
-    @type even_ctf_sum: L{pytom_volume.vol}
+    @type even_ctf_sum: L{pytom.lib.pytom_volume.vol}
     @param odd_ctf_sum: odd ctf sum volume, normalized over the number of particles in the half set, reduced complex
-    @type odd_ctf_sum: L{pytom_volume.vol}
+    @type odd_ctf_sum: L{pytom.lib.pytom_volume.vol}
     @param fudge: relion fudge factor (T)
     @type fudge: L[float}
     @return: returns two filters for the odd and even half map filter1, filter2
-    @rtype: L{[pytom_volume.vol, pytom_volume.vol]}
+    @rtype: L{[pytom.lib.pytom_volume.vol, pytom.lib.pytom_volume.vol]}
     """
     assert even_ctf_sum.sizeX() == even_ctf_sum.sizeY() and even_ctf_sum.sizeX() // 2 + 1 == even_ctf_sum.sizeZ(), \
         'even volume does not have correct dimensions'

--- a/pytom/basic/fourier.py
+++ b/pytom/basic/fourier.py
@@ -1,4 +1,4 @@
-from pytom_volume import reducedToFull
+from pytom.lib.pytom_volume import reducedToFull
 from math import sqrt, ceil
 
 
@@ -41,7 +41,7 @@ class FtSingleton(object):
         """
         findInFt: Checks for Fourier Tuple with same volume size. 
         @param volume:
-        @type volume: L{pytom_volume.vol} 
+        @type volume: L{pytom.lib.pytom_volume.vol} 
         @return: 
         @author: Thomas Hrabe 
         """
@@ -101,17 +101,17 @@ def fft(data, scaling=''):
     """
     fft: Performs Fourier Transformation on input. The result is NOT scaled in any way (1/N , 1/sqrt(n),...)  
     @param data: The source volume.  
-    @type data: pytom_volume.vol
+    @type data: pytom.lib.pytom_volume.vol
     @param scaling: Describes the type of scaling is applied. 'N' 1/N, 'sqrtN' 1/sqrt(N). '' no scaling (default)
     @type scaling: str
-    @rtype: pytom_volume.vol_comp
+    @rtype: pytom.lib.pytom_volume.vol_comp
     @return: The fourier transformed data 
     @author: Thomas Hrabe
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     
     if not data.__class__ == pytom_volume.vol:
-        raise TypeError('Data must be of type pytom_volume.vol')
+        raise TypeError('Data must be of type pytom.lib.pytom_volume.vol')
     
     
     ftSingleton = FtSingleton()
@@ -142,7 +142,7 @@ def fft(data, scaling=''):
         return returnValue
     
     else:  
-        import pytom_fftplan
+        import pytom.lib.pytom_fftplan as pytom_fftplan
     
         real = pytom_volume.vol(data.sizeX(),data.sizeY(),data.sizeZ())
         real.copyVolume(data)
@@ -180,17 +180,17 @@ def ifft(Fdata, scaling=''):
     """
     ifft: Performs inverse Fourier Transformation on input. The result is NOT scaled in any way (1/N , 1/sqrt(n),...)
     @param Fdata: The source volume (must be complex). If FData does not have shape information of the real volume, PyTom will assume that x==y==z (See line 198)   
-    @type Fdata: pytom_volume.vol_comp
+    @type Fdata: pytom.lib.pytom_volume.vol_comp
     @param scaling: Describes the type of scaling is applied. 'N' 1/N, 'sqrtN' 1/sqrt(N). '' no scaling (default)
     @type scaling: str
-    @rtype: pytom_volume.vol
+    @rtype: pytom.lib.pytom_volume.vol
     @return: The inverse fourier transformed data
     @author: Thomas Hrabe
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     
     if not Fdata.__class__ == pytom_volume.vol_comp:
-        raise TypeError('Data must be of type pytom_volume.vol_comp')
+        raise TypeError('Data must be of type pytom.lib.pytom_volume.vol_comp')
     
     if scaling: Fdata = Fdata/Fdata.getFtSizeX()/Fdata.getFtSizeY()/Fdata.getFtSizeZ()
 
@@ -216,7 +216,7 @@ def ifft(Fdata, scaling=''):
         return returnValue
     
     else:  
-        import pytom_fftplan
+        import pytom.lib.pytom_fftplan as pytom_fftplan
     
         complexVolume = pytom_volume.vol_comp(Fdata.sizeX(),Fdata.sizeY(),Fdata.sizeZ())
         complexVolume.copyVolume(Fdata)
@@ -260,18 +260,18 @@ def ftshift(data, inplace = True):
     """
     ftshift: Performs a forward fourier shift of data. Data must be full, the center is not determined accordingly. Assumes center is always size/2.
     @param data: - a volume
-    @type data: pytom_volume.vol or pytom_volume.vol_comp
+    @type data: pytom.lib.pytom_volume.vol or pytom.lib.pytom_volume.vol_comp
     @param inplace: true by default
     @type inplace: boolean
     @return: data shifted
     @author: Thomas Hrabe
     """
-    import pytom_fftplan
+    import pytom.lib.pytom_fftplan as pytom_fftplan
     if inplace:
         pytom_fftplan.fftShift(data,False)
         return None
     else:
-        from pytom_volume import vol, vol_comp
+        from pytom.lib.pytom_volume import vol, vol_comp
         if data.__class__ == vol:
             dummy = vol(data)
         elif data.__class__ == vol_comp:
@@ -283,16 +283,16 @@ def iftshift(data, inplace = True):
     """
     iftshift: Performs a inverse fourier shift of data. Data must be full, the center is not determined accordingly. Assumes center is always size/2.
     @param data: - a volume
-    @type data: pytom_volume.vol or pytom_volume.vol_comp 
+    @type data: pytom.lib.pytom_volume.vol or pytom.lib.pytom_volume.vol_comp 
     @return: data inverse shifted
     @author: Thomas Hrabe
     """
-    import pytom_fftplan
+    import pytom.lib.pytom_fftplan as pytom_fftplan
     if inplace:
         pytom_fftplan.fftShift(data,True)
         return data
     else:
-        from pytom_volume import vol, vol_comp
+        from pytom.lib.pytom_volume import vol, vol_comp
         if data.__class__ == vol:
             dummy = vol(data)
         elif data.__class__ == vol_comp:
@@ -303,21 +303,21 @@ def iftshift(data, inplace = True):
 def convolute(v, k, kernel_in_fourier=False):
     """
     @param v: the volume to be convolute
-    @type v: L{pytom_volume.vol}
+    @type v: L{pytom.lib.pytom_volume.vol}
     @param k: the convolution kernel in real space
-    @type k: L{pytom_volume.vol}
+    @type k: L{pytom.lib.pytom_volume.vol}
     @param kernel_in_fourier: the given kernel is already in Fourier space or not (full size, shifted in the center! \
         or reduced size). Default is False.
     @type kernel_in_fourier: L{bool}
     @return: Volume convoluted with kernel
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     """
     fv = fft(v)
     if not kernel_in_fourier:
         fk = fft(k)
         res = fv*fk
     else:
-        from pytom_volume import complexRealMult, fullToReduced
+        from pytom.lib.pytom_volume import complexRealMult, fullToReduced
         if k.sizeZ() == k.sizeX():
             fk = fullToReduced(ftshift(k, inplace=False))
         else:
@@ -372,15 +372,14 @@ def powerspectrum(volume):
     compute power spectrum of a volume
     
     @param volume: input volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @return: power spectrum of vol
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
 
     @author: FF
     """
     from pytom.basic.fourier import fft, ftshift
-    from pytom_volume import vol
-    from pytom_volume import reducedToFull
+    from pytom.lib.pytom_volume import vol, reducedToFull
 
     fvol = ftshift(reducedToFull(fft(volume)),inplace=False)
     nx=fvol.sizeX()
@@ -401,7 +400,7 @@ def radialaverage(volume, isreduced=True):
     """
     Calculate the radial average from a Fourier space volume.
     @param volume: input fourier space volume with 0 frequency in center
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param isreduced: if reduced will be made to full and then ftshift'ed
     @type isreduced: L{bool}
 

--- a/pytom/basic/functions.py
+++ b/pytom/basic/functions.py
@@ -22,7 +22,7 @@ def initSphere(sizeX, sizeY, sizeZ, radius, smooth=0, maxradius=0, cent=None, fi
     @type cent: array (3-dim)
     @param filename: If specified by the user, the spherical mask will be written to disk.    
     """
-    from pytom_volume import initSphere, vol
+    from pytom.lib.pytom_volume import initSphere, vol
     
         
     v = vol(sizeX,sizeY,sizeZ)
@@ -46,7 +46,7 @@ def taper_edges(image, width, taper_mask=None):
     @param width: width of edge
     @type width: int
     @param taper_mask: mask for tapering - if None it will be generated
-    @type taper_mask: L{pytom_volume.vol}
+    @type taper_mask: L{pytom.lib.pytom_volume.vol}
 
     @return: image with smoothened edges, taper_mask
     @rtype: array-like
@@ -54,10 +54,10 @@ def taper_edges(image, width, taper_mask=None):
     @author: FF
     """
     import numpy
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from math import cos, pi
 
-    assert type(image) == vol, "taper_edges: image must be type pytom_volume.vol"
+    assert type(image) == vol, "taper_edges: image must be type pytom.lib.pytom_volume.vol"
     dims = [image.sizeX(), image.sizeY(), image.sizeZ()]
     assert dims[0]>1, "taper_edges: image must be 2D or 3D"
     assert dims[1]>1, "taper_edges: image must be 2D or 3D"
@@ -108,7 +108,7 @@ def limit_in_sphere( invol, r_max=None, lowlimit=None, lowval=0., hilimit=None, 
     limit grey values of volume within center radius
 
     @param invol: input volume
-    @type invol: L{pytom_volume.vol} or L{pytom_volume.vol_comp}
+    @type invol: L{pytom.lib.pytom_volume.vol} or L{pytom.lib.pytom_volume.vol_comp}
     @param r_max: radius
     @type r_max: L{int}
     @param lowlimit: lower limit - all values below this value that lie in the specified radius will be replaced \
@@ -178,15 +178,15 @@ def scale(volume,factor,interpolation='Spline'):
     if factor <=0:
         raise RuntimeError('Scaling factor must be > 0!')
     
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from math import ceil
     
     if interpolation == 'Spline':
-        from pytom_volume import rescaleSpline as rescale
+        from pytom.lib.pytom_volume import rescaleSpline as rescale
     elif interpolation == 'Lagrange':
-        from pytom_volume import rescaleCubic as rescale
+        from pytom.lib.pytom_volume import rescaleCubic as rescale
     elif interpolation == 'Linear':
-        from pytom_volume import rescale
+        from pytom.lib.pytom_volume import rescale
          
     
     sizeX = volume.sizeX()
@@ -224,7 +224,7 @@ def mirror(volume,axis = 'x',copyFlag = True):
     centerZ = volume.sizeZ()
     
     if copyFlag:
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         returnVolume = vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
         
         for x in range(volume.sizeX()):

--- a/pytom/basic/normalise.py
+++ b/pytom/basic/normalise.py
@@ -9,7 +9,7 @@ def mean0std1(volume,copyFlag=False):
     @return: If copyFlag == True, then return a normalised copy.
     @author: Thomas Hrabe
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     from math import sqrt
     from pytom.tools.maths import epsilon
     
@@ -60,7 +60,7 @@ def normaliseUnderMask(volume, mask, p=None):
     from pytom.tools.maths import epsilon
     #from math import sqrt
     if not p:
-        from pytom_volume import sum
+        from pytom.lib.pytom_volume import sum
         p = sum(mask)
     #meanT = sum(volume) / p
     ## subtract mean and mask
@@ -86,13 +86,13 @@ def subtractMeanUnderMask(volume, mask):
     subtract mean from volume/image under mask 
 
     @param volume: volume/image
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param mask: mask
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @return: volume/image
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     """
-    from pytom_volume import sum as sumvol
+    from pytom.lib.pytom_volume import sum as sumvol
     from pytom.tools.maths import epsilon
     #npix = volume.sizeX() * volume.sizeY() * volume.sizeZ()
     normvol = volume*mask

--- a/pytom/basic/score.py
+++ b/pytom/basic/score.py
@@ -4,14 +4,14 @@ def Vol_G_Val(volume,value):
     """
     Vol_GE_Val: returns True when peak in volume greater than value
     @param volume: A volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param value: A value
-    @type value: L{pytom_volume.vol}
+    @type value: L{pytom.lib.pytom_volume.vol}
     @return: True if peak in volume > value
     @rtype: boolean
     @author: Thomas Hrabe
     """
-    import pytom_volume
+    import pytom.lib.pytom_volume as pytom_volume
     
     if value.__class__ == pytom_volume.vol:
         p = pytom_volume.peak(value)
@@ -28,13 +28,13 @@ def weightedCoefficient(self,volume,reference,mask=None,stdV=None):
     weightedCoefficient: Determines the peak coefficient of the scoring function. 
     The distance from the center contributes to the peak value. Must be activated by hand. 
     @param volume: A volume.
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param reference: A reference.
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param mask: A mask.
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param stdV: Deviation volume of volume  
-    @type stdV: L{pytom_volume.vol}
+    @type stdV: L{pytom.lib.pytom_volume.vol}
     @return: The highest coefficient determined.
     @author: Thomas Hrabe
     """
@@ -48,13 +48,13 @@ def peakCoef(self, volume, reference, mask=None):
     """
     peakCoef: Determines the coefficient of the scoring function.
     @param volume: A volume.
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param reference: A reference.
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @return: The highest coefficient determined.
     @author: Thomas Hrabe, FF
     """
-    from pytom_volume import peak
+    from pytom.lib.pytom_volume import peak
     from pytom.tools.maths import euclidianDistance
     from pytom.basic.correlation import subPixelPeak
     
@@ -202,13 +202,13 @@ class Score:
         """
         returns weighted Coefficient
         @param volume: A volume.
-        @type volume: L{pytom_volume.vol}
+        @type volume: L{pytom.lib.pytom_volume.vol}
         @param reference: A reference.
-        @type reference: L{pytom_volume.vol}
+        @type reference: L{pytom.lib.pytom_volume.vol}
         @param mask: A mask.
-        @type mask: L{pytom_volume.vol}
+        @type mask: L{pytom.lib.pytom_volume.vol}
         @param stdV: Deviation volume of volume  
-        @type stdV: L{pytom_volume.vol}
+        @type stdV: L{pytom.lib.pytom_volume.vol}
         @return: The highest coefficient determined.
         """
         return self.weightedCoefficient(self, particle, reference, mask, stdV)
@@ -477,13 +477,13 @@ class FLCFScore(Score):
         """
         peakCoef: Determines the coefficient of the scoring function.
         @param volume: A volume.
-        @type volume: L{pytom_volume.vol}
+        @type volume: L{pytom.lib.pytom_volume.vol}
         @param reference: A reference.
-        @type reference: L{pytom_volume.vol}
+        @type reference: L{pytom.lib.pytom_volume.vol}
         @return: The highest coefficient determined.
         @author: Thomas Hrabe, FF
         """
-        from pytom_volume import peak
+        from pytom.lib.pytom_volume import peak
         from pytom.tools.maths import euclidianDistance
         from pytom.basic.correlation import subPixelPeak
 
@@ -674,7 +674,7 @@ class PeakPrior(PyTomClass):
         return self._smooth()
     
     def isInitialized(self):
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         return self._weight.__class__ == vol
              
     def apply(self,volume):
@@ -694,12 +694,12 @@ class PeakPrior(PyTomClass):
         
         assert volumesSameSize(self._weight,volume)#make sure both have same size
 
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
 
         return (self._weight * volume) #- (self._weight <= 0.000001)*2
     
     def fromFile(self,filename=None):
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.tools.files import checkFileExists
         
         filename = filename or self._filename
@@ -730,7 +730,7 @@ class PeakPrior(PyTomClass):
         @return: 
         @author: Thomas Hrabe 
         """
-        from pytom_volume import vol,initSphere
+        from pytom.lib.pytom_volume import vol,initSphere
         
         self._weight = vol(sizeX,sizeY,sizeZ)
         if self._radius > 0 or self._smooth > 0:

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -10,8 +10,8 @@ from math import pi, sin, cos
 from scipy.ndimage.interpolation import map_coordinates
 from pytom.basic.files import read
 from pytom.basic.filter import rotateWeighting
-from pytom_volume import reducedToFull, vol
-from pytom_numpy import vol2npy
+from pytom.lib.pytom_volume import reducedToFull, vol
+from pytom.lib.pytom_numpy import vol2npy
 from pytom.basic.fourier import convolute, ftshift
 analytWedge=False
 
@@ -244,8 +244,7 @@ class Mask(PyTomClass):
             if not checkFileExists(self._filename):
                 raise IOError('Could not find mask named: ' + self._filename)
             
-            from pytom_volume import read
-            from pytom_volume import read
+            from pytom.lib.pytom_volume import read
             from pytom.tools.files import checkFileExists
             from pytom.basic.transformations import resize
 
@@ -263,7 +262,7 @@ class Mask(PyTomClass):
 	        #self._binning,self._binning)
             
         if rotation and not(self._isSphere):
-            from pytom_volume import vol,transform 
+            from pytom.lib.pytom_volume import vol,transform 
             from pytom.basic.maths import determineRotationCenter
             
             if rotation.__class__ == list:
@@ -477,7 +476,7 @@ class Reference(PyTomClass):
         """
         
 
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.tools.files import checkFileExists
         from pytom.basic.transformations import resize
 
@@ -499,7 +498,7 @@ class Reference(PyTomClass):
         @return: Sum of wedges
         """
         
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.tools.files import checkFileExists
         
         if self._referenceWeighting == '':
@@ -516,7 +515,7 @@ class Reference(PyTomClass):
         @return: Reference before wedge weighting
         """
         
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.tools.files import checkFileExists
         
         if self._preWedgeFile == '':
@@ -535,12 +534,12 @@ class Reference(PyTomClass):
         @param verbose: talkative
         @type verbose: bool
         @return: [newReferenceVolume,newSumOfWedges]
-        @rtype: [L{pytom_volume.vol},L{pytom_volume.vol}]
+        @rtype: [L{pytom.lib.pytom_volume.vol},L{pytom.lib.pytom_volume.vol}]
         @change: more accurate binning now in Fourier space - FF
         """
         #if flag is set and both files exist, do subtract particle from reference 
 
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.basic.fourier import convolute
         from pytom.basic.filter import rotateWeighting
         from pytom.alignment.alignmentFunctions import invert_WedgeSum
@@ -838,7 +837,7 @@ class Wedge(PyTomClass):
         @param wedgeSizeX: volume size for x (original size)
         @param wedgeSizeY: volume size for y (original size)
         @param wedgeSizeZ: volume size for z (original size)
-        @rtype: L{pytom_freqweight.weight}
+        @rtype: L{pytom.lib.pytom_freqweight.weight}
         @return: Weighting object. Remember, the wedge will be cutoff at sizeX/2 if no cutoff provided in constructor or cutoff == 0!
         @author: Thomas Hrabe   
         """
@@ -857,7 +856,7 @@ class Wedge(PyTomClass):
         @param humanUnderstandable: if True (default is False), the volume will be transformed from reducedComplex to full and shifted afterwards
         @param rotation: rotation of wedge
 
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe 
         """
         
@@ -877,9 +876,9 @@ class Wedge(PyTomClass):
         """
         apply: Applies this wedge to a given volume
         @param volume: The volume to be filtered
-        @type volume: L{pytom_volume.vol} or L{pytom_volume.vol_comp}
+        @type volume: L{pytom.lib.pytom_volume.vol} or L{pytom.lib.pytom_volume.vol_comp}
         @return: The filtered volume
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe
         """
         
@@ -1078,11 +1077,11 @@ class SingleTiltWedge(PyTomClass):
         @param wedgeSizeZ: volume size for z (original size)
         @param rotation: Apply rotation to the wedge
         @type rotation: L{pytom.basic.structures.Rotation}  
-        @rtype: L{pytom_freqweight.weight}
+        @rtype: L{pytom.lib.pytom_freqweight.weight}
         @return: Weighting object. Remember, the wedge will be cutoff at sizeX/2 if no cutoff provided in constructor or cutoff == 0!
         @author: Thomas Hrabe   
         """
-        from pytom_freqweight import weight
+        from pytom.lib.pytom_freqweight import weight
         from pytom.basic.structures import Rotation
         if self._cutoffRadius  == 0.0:
             cut = wedgeSizeX//2
@@ -1109,13 +1108,13 @@ class SingleTiltWedge(PyTomClass):
         be transformed from reducedComplex to full and shifted afterwards
         @param rotation: rotation of wedge
 
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe 
         """
         wedgeVolume = None
 
         if self._wedgeAngle1 == 0 and self._wedgeAngle2 == 0:
-            from pytom_volume import vol
+            from pytom.lib.pytom_volume import vol
             
             if not humanUnderstandable:
                 wedgeVolume = vol(wedgeSizeX,wedgeSizeY,int(wedgeSizeZ/2)+1)
@@ -1132,8 +1131,8 @@ class SingleTiltWedge(PyTomClass):
                 
             if humanUnderstandable:
                 # applies hermitian symmetry to full and ftshift so that even humans do understand
-                from pytom_fftplan import fftShift
-                from pytom_volume import reducedToFull
+                from pytom.lib.pytom_fftplan import fftShift
+                from pytom.lib.pytom_volume import reducedToFull
                 wedgeVolume = reducedToFull(wedgeVolume)
                 
                 fftShift(wedgeVolume,True)
@@ -1148,17 +1147,17 @@ class SingleTiltWedge(PyTomClass):
         """
         apply: Applies this wedge to a given volume
         @param volume: The volume to be filtered
-        @type volume: L{pytom_volume.vol} or L{pytom_volume.vol_comp}
+        @type volume: L{pytom.lib.pytom_volume.vol} or L{pytom.lib.pytom_volume.vol_comp}
         @param rotation: rotate the wedge
         @type rotation: L{pytom.basic.structures.Rotation}
         @return: The filtered volume
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         
         if not volume.__class__ == vol:
-            raise TypeError('SingleTiltWedge: You must provide a pytom_volume.vol here!')
+            raise TypeError('SingleTiltWedge: You must provide a pytom.lib.pytom_volume.vol here!')
         
         if self._wedgeAngle1 > 0 or self._wedgeAngle2 > 0:
             
@@ -1358,10 +1357,10 @@ be generated. If omitted / 0, filter is fixed to size/2.
             be transformed from reducedComplex to full and shifted afterwards
         @param rotation: rotation of 2nd wedge with respect to 1st
         @return: average of both wedges
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe 
         """
-        from pytom_volume import vol, limit
+        from pytom.lib.pytom_volume import vol, limit
         
         w1 = self._wedge1.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
         w2 = self._wedge2.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
@@ -1456,17 +1455,17 @@ be generated. If omitted / 0, filter is fixed to size/2.
         """
         apply: Applies this wedge to a given volume
         @param volume: The volume to be filtered
-        @type volume: L{pytom_volume.vol} or L{pytom_volume.vol_comp}
+        @type volume: L{pytom.lib.pytom_volume.vol} or L{pytom.lib.pytom_volume.vol_comp}
         @param rotation: rotate the wedge
         @type rotation: L{pytom.basic.structures.Rotation}
         @return: The filtered volume
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe
         """
-        from pytom_volume import vol,complexRealMult
+        from pytom.lib.pytom_volume import vol,complexRealMult
         from pytom.basic.fourier import fft,ifft
         if not volume.__class__ == vol:
-            raise TypeError('You must provide a pytom_volume.vol here!')
+            raise TypeError('You must provide a pytom.lib.pytom_volume.vol here!')
     
         wedgeVolume = self.returnWedgeVolume(volume.sizeX(),volume.sizeY(),volume.sizeZ(),
                            humanUnderstandable = False,rotation=rotation)
@@ -1524,7 +1523,7 @@ class Wedge3dCTF(PyTomClass):
     def apply(self, volume, rotation=None):
 
         if not volume.__class__ == vol:
-            raise TypeError('Wedge3dCTF: You must provide a pytom_volume.vol here!')
+            raise TypeError('Wedge3dCTF: You must provide a pytom.lib.pytom_volume.vol here!')
 
         wedge = self.returnWedgeVolume(rotation=rotation)
 
@@ -1616,7 +1615,7 @@ class GeneralWedge(PyTomClass):
     
     def _read_weight(self):
         if self._weight_vol is None:
-            from pytom_volume import read
+            from pytom.lib.pytom_volume import read
             w = read(self._wedge_filename)
             
             self._weight_vol = w
@@ -1630,7 +1629,7 @@ class GeneralWedge(PyTomClass):
         self._wedge_filename = filename
     
     def returnWedgeFilter(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, rotation=None):
-        from pytom_freqweight import weight
+        from pytom.lib.pytom_freqweight import weight
         from pytom.basic.structures import Rotation
         
         self._read_weight()
@@ -1649,8 +1648,8 @@ class GeneralWedge(PyTomClass):
             
         if humanUnderstandable:
             # applies hermitian symmetry to full and ftshift so that even humans do understand 
-            from pytom_fftplan import fftShift
-            from pytom_volume import reducedToFull
+            from pytom.lib.pytom_fftplan import fftShift
+            from pytom.lib.pytom_volume import reducedToFull
             wedgeVolume = reducedToFull(wedgeVolume)
                 
             fftShift(wedgeVolume,True)
@@ -1658,9 +1657,9 @@ class GeneralWedge(PyTomClass):
         return wedgeVolume
     
     def apply(self, volume, rotation=None):
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         if not volume.__class__ == vol:
-            raise TypeError('You must provide a pytom_volume.vol here!')
+            raise TypeError('You must provide a pytom.lib.pytom_volume.vol here!')
         
         from pytom.basic.filter import filter
         wedgeFilter = self.returnWedgeFilter(None, None, None, rotation)
@@ -1688,7 +1687,7 @@ class GeneralWedge(PyTomClass):
         # start sampling
         import numpy as np
         from math import pi, sin, cos
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
         from scipy.ndimage.interpolation import map_coordinates
         v = vol2npy(self._weight_vol)
         
@@ -1866,10 +1865,10 @@ class Particle(PyTomClass):
         @param binning: binning factor (e.g., 2 makes it 2 times smaller in each dim)
         @type binning: int or float
         @return: volume
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         @change: FF
         """
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.tools.files import checkFileExists
         from pytom.basic.transformations import resize
         
@@ -2111,7 +2110,7 @@ class Particle(PyTomClass):
         getTransformedVolume: Returns particle volume with applied inverse rotation and inverse shift
         @param binning: binning factor
         @type binning: C{int}
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
         from pytom.basic.structures import Shift,Rotation
         volume = self.getVolume(binning)
@@ -2120,7 +2119,7 @@ class Particle(PyTomClass):
         rotation = self.getRotation()
         
         if rotation != Rotation(0,0,0) or shift != Shift(0,0,0):
-            from pytom_volume import vol, transformSpline
+            from pytom.lib.pytom_volume import vol, transformSpline
             
             volumeTransformed = vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
         
@@ -2428,7 +2427,7 @@ class ParticleList(PyTomClass):
         @param particleStartOffset: Offset in particle indexing. Motls generated with MATLAB will most likely start with a 1 as first particle (not with 0 as in C or Python) 
         @type particleStartOffset: C{int}
         """
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.tools.files import checkFileExists
         
         from pytom.basic.structures import Rotation,Shift,PickPosition,Particle
@@ -2470,7 +2469,7 @@ class ParticleList(PyTomClass):
         @warning: Resulting MOTL - Particle Index (4th entry) is increment 1:numberParticles. Does not neccessarily match to the particleFilename! Check L{copyFiles} for that.
         @param filename: The filename  
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         
         numberParticles = len(self)
         
@@ -2964,7 +2963,7 @@ class ParticleList(PyTomClass):
         @type progressBar: bool
         """
         from pytom.tools.files import checkDirExists
-        import pytom_mpi
+        import pytom.lib.pytom_mpi as pytom_mpi
         
         if not checkDirExists(directory):
             raise RuntimeError('Directory specified does not exist!')
@@ -2974,7 +2973,7 @@ class ParticleList(PyTomClass):
         for i in range(len(pls)):
             particle = pls[i][0]
             className = particle.getClassName()
-            pls[i].average(directory + '/class_' + str(className) + '.em',progressBar,False,pytom_mpi.isInitialised())
+            pls[i].average(directory + '/class_' + str(className) + '.em',progressBar,False, pytom_mpi.isInitialised())
             
     def splitOddEven(self, verbose=False):
         """
@@ -3037,10 +3036,10 @@ class ParticleList(PyTomClass):
         if len(self) < 2:
             raise RuntimeError('ParticleList must have at least 2 elements to determine resolution!')
     
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.basic.correlation import FSC, determineResolution
-        import pytom_mpi
-        from pytom_numpy import vol2npy
+        import pytom.lib.pytom_mpi as pytom_mpi
+        from pytom.lib.pytom_numpy import vol2npy
 
         import os 
         
@@ -3274,13 +3273,13 @@ class ParticleList(PyTomClass):
         """
         Calculate the variance map on the aligned particle list.
         @param average: average of the aligned particle list
-        @type average: L{pytom_volume.vol}
+        @type average: L{pytom.lib.pytom_volume.vol}
         @param verbose: verbose mode
         @type verbose: L{boolean}
         @return: 3D variance map
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
-        from pytom_volume import power, complexDiv, mean, variance
+        from pytom.lib.pytom_volume import power, complexDiv, mean, variance
         from pytom.basic.fourier import fft,ifft
         from math import sqrt
         from pytom.tools.ProgressBar import FixedProgBar
@@ -3333,17 +3332,17 @@ class ParticleList(PyTomClass):
         Calculate the standard deviation map using getVarianceMap function.
 
         @param average: average of the aligned particle list
-        @type average: L{pytom_volume.vol}
+        @type average: L{pytom.lib.pytom_volume.vol}
         @param verbose: verbose mode
         @type verbose: L{boolean}
         @return: 3D standard deviation map
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
         if average is None:
             from pytom.alignment.alignmentFunctions import average2
             average, fsc = average2(self, False, False, False, mask, verbose=verbose)
         
-        from pytom_volume import abs, power
+        from pytom.lib.pytom_volume import abs, power
         vm = self.getVarianceMap(average, verbose)
         
         std_map = abs(vm) # sometimes it can have negative values
@@ -3359,7 +3358,7 @@ class ParticleList(PyTomClass):
     def getCVMap(self, average=None, std_map=None, threshold=None, negative_density=True, verbose=True):
         """Calculate the coefficient of variance map.
         """
-        from pytom_volume import vol, limit, variance, mean, abs
+        from pytom.lib.pytom_volume import vol, limit, variance, mean, abs
         if average is None:
             from pytom.alignment.alignmentFunctions import average2
             average, fsc = average2(self, False, False, False, verbose=verbose)
@@ -4485,8 +4484,8 @@ class PointSymmetry(Symmetry):
         from pytom.angles.localSampling import LocalSampling
         from pytom.basic.correlation import nxcc
         from pytom.basic.structures import Mask
-        from pytom_volume import vol
-        from pytom_volume import rotateSpline as rotate
+        from pytom.lib.pytom_volume import vol
+        from pytom.lib.pytom_volume import rotateSpline as rotate
          
         if axis == 'Z' or axis.__class__ != list:
             rotations = LocalSampling(0,angularIncrement)
@@ -4531,7 +4530,7 @@ class PointSymmetry(Symmetry):
         applyToParticle: symmetrize particle 
         @param volume: The volume
         """
-        from pytom_volume import vol, rotateSpline
+        from pytom.lib.pytom_volume import vol, rotateSpline
         from pytom.basic.structures import Rotation
         
         sizeX = volume.sizeX()
@@ -4697,7 +4696,7 @@ class HelicalSymmetry(Symmetry):
         return newList
 
     def applyToPatricle(self,particle):
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from pytom.basic.structures import Rotation,Shift
         from pytom.basic.transformations import rotate,shift
         

--- a/pytom/basic/transformations.py
+++ b/pytom/basic/transformations.py
@@ -18,7 +18,7 @@ def shift(volume,shiftX,shiftY,shiftZ,imethod='fourier',twice=False):
     @author: Yuxiang Chen and Thomas Hrabe 
     """
     if imethod == 'fourier':
-        from pytom_volume import vol_comp,reducedToFull,fullToReduced,shiftFourier
+        from pytom.lib.pytom_volume import vol_comp,reducedToFull,fullToReduced,shiftFourier
         from pytom.basic.fourier import fft,ifft,ftshift, iftshift
 
         fvolume = fft(volume)
@@ -35,13 +35,13 @@ def shift(volume,shiftX,shiftY,shiftZ,imethod='fourier',twice=False):
         return v
         
     else:
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         if imethod == 'linear':
-            from pytom_volume import transform
+            from pytom.lib.pytom_volume import transform
         elif imethod == 'cubic':
-            from pytom_volume import transformCubic as transform
+            from pytom.lib.pytom_volume import transformCubic as transform
         elif imethod == 'spline':
-            from pytom_volume import transformSpline as transform
+            from pytom.lib.pytom_volume import transformSpline as transform
         # now results should be consistent with python2
         centerX = int(volume.sizeX()//2)
         centerY = int(volume.sizeY()//2)
@@ -80,13 +80,13 @@ def rotate(volume,rotation,x=None,z2=None,imethod='spline',twice=False):
         return transformFourierSpline(volume,z1,z2,x,0,0,0,twice)
         
     else:
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         if imethod == 'linear':
-            from pytom_volume import transform
+            from pytom.lib.pytom_volume import transform
         elif imethod == 'cubic':
-            from pytom_volume import transformCubic as transform
+            from pytom.lib.pytom_volume import transformCubic as transform
         elif imethod == 'spline':
-            from pytom_volume import transformSpline as transform
+            from pytom.lib.pytom_volume import transformSpline as transform
             
         centerX = volume.sizeX()/2
         centerY = volume.sizeY()/2
@@ -112,7 +112,7 @@ def transformFourierSpline(volume,z1,z2,x,shiftX,shiftY,shiftZ,twice=False):
     @author: Yuxiang Chen and Thomas Hrabe
     """
     from pytom.basic.fourier import fft, ifft, ftshift, iftshift
-    from pytom_volume import vol, pasteCenter, subvolume, transformFourierSpline
+    from pytom.lib.pytom_volume import vol, pasteCenter, subvolume, transformFourierSpline
     
     if z1 == 0 and z2 == 0 and x == 0:
         return vol(volume)
@@ -148,7 +148,7 @@ def rotateFourierSpline(volume,z1,z2,x,twice=False):
     """
     
 #    from pytom.basic.fourier import fft, ifft, ftshift, iftshift
-#    from pytom_volume import vol, pasteCenter, subvolume, rotateSplineInFourier
+#    from pytom.lib.pytom_volume import vol, pasteCenter, subvolume, rotateSplineInFourier
 #    
 #    if z1 == 0 and z2 == 0 and x == 0:
 #        return vol(volume)
@@ -179,7 +179,7 @@ def scale(volume,factor,interpolation='Spline'):
     scale: Scale a volume by a factor in REAL SPACE - see also resize function for more accurate operation in Fourier \
     space
     @param volume: input volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param factor: a factor > 0. Factors < 1 will de-magnify the volume, factors > 1 will magnify.
     @type factor: L{float}
     @param interpolation: Can be Spline (default), Cubic or Linear
@@ -192,15 +192,15 @@ def scale(volume,factor,interpolation='Spline'):
     if factor <=0:
         raise RuntimeError('Scaling factor must be > 0!')
     
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     from math import ceil
     
     if interpolation == 'Spline':
-        from pytom_volume import rescaleSpline as rescale
+        from pytom.lib.pytom_volume import rescaleSpline as rescale
     elif interpolation == 'Cubic':
-        from pytom_volume import rescaleCubic as rescale
+        from pytom.lib.pytom_volume import rescaleCubic as rescale
     elif interpolation == 'Linear':
-        from pytom_volume import rescale
+        from pytom.lib.pytom_volume import rescale
          
     
     sizeX = volume.sizeX()
@@ -219,14 +219,14 @@ def resize(volume, factor, interpolation='Fourier'):
     """
     resize volume in real or Fourier space
     @param volume: input volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param factor: a factor > 0. Factors < 1 will de-magnify the volume, factors > 1 will magnify.
     @type factor: L{float}
     @param interpolation: Can be 'Fourier' (default), 'Spline', 'Cubic' or 'Linear'
     @type interpolation: L{str}
 
     @return: The re-sized volume
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
 
@@ -246,14 +246,14 @@ def resizeFourier(fvol, factor):
     resize Fourier transformed by factor
 
     @param fvol: Fourier transformed of a volume  - reduced complex
-    @type fvol: L{pytom_volume.vol_comp}
+    @type fvol: L{pytom.lib.pytom_volume.vol_comp}
     @param factor:  a factor > 0. Factors < 1 will de-magnify the volume, factors > 1 will magnify.
     @type factor: float
     @return: resized Fourier volume (deruced complex)
-    @rtype: L{pytom_volume.vol_comp}
+    @rtype: L{pytom.lib.pytom_volume.vol_comp}
     @author: FF
     """
-    from pytom_volume import vol_comp
+    from pytom.lib.pytom_volume import vol_comp
 
     assert isinstance(fvol, vol_comp), "fvol must be reduced complex"
 
@@ -362,7 +362,7 @@ def mirror(volume,axis = 'x',copyFlag = True):
     centerZ = volume.sizeZ()
     
     if copyFlag:
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         returnVolume = vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
         
         for x in range(volume.sizeX()):
@@ -473,7 +473,7 @@ def general_transform_crop(v, rot=None, shift=None, scale=None, order=[0, 1, 2],
     AND magnification!
 
     @param v: volume
-    @type v: L{pytom_volume.vol}
+    @type v: L{pytom.lib.pytom_volume.vol}
     @param rot: rotate
     @type rot: pytom.basic.structures.Rotate or list
     @param shift: shift
@@ -485,13 +485,13 @@ def general_transform_crop(v, rot=None, shift=None, scale=None, order=[0, 1, 2],
     @type order: list
     @param center: optional list with center coordinates in pixels
     @type center: list of 3 floats
-    @return: pytom_volume
+    @return: pytom.lib.pytom_volume
 
     @author: FF
     """
-    from pytom_volume import vol, general_transform
+    from pytom.lib.pytom_volume import vol, general_transform
     if not isinstance(v,vol):
-        raise TypeError('general_transform_crop: v must be of type pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
+        raise TypeError('general_transform_crop: v must be of type pytom.lib.pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
 
     mtx = general_transform_matrix([v.sizeX(), v.sizeY(), v.sizeZ()], rot=rot, shift=shift, scale=scale, order=order,
                                    center=center)
@@ -503,7 +503,7 @@ def general_transform_crop(v, rot=None, shift=None, scale=None, order=[0, 1, 2],
 def general_transform(v, rot=None, shift=None, scale=None, order=[0, 1, 2], center=None):
     """Perform general transformation using 3rd order spline interpolation.
     @param v: volume
-    @type v: L{pytom_volume.vol}
+    @type v: L{pytom.lib.pytom_volume.vol}
     @param rot: rotate
     @type rot: pytom.basic.structures.Rotate or list
     @param shift: shift
@@ -514,11 +514,11 @@ def general_transform(v, rot=None, shift=None, scale=None, order=[0, 1, 2], cent
     @type order: list
     @param center: optional list with center coordinates in pixels
     @type center: list of 3 floats
-    @return: pytom_volume
+    @return: pytom.lib.pytom_volume
     """
-    from pytom_volume import vol, general_transform
+    from pytom.lib.pytom_volume import vol, general_transform
     if not isinstance(v,vol):
-        raise TypeError('general_transform: v must be of type pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
+        raise TypeError('general_transform: v must be of type pytom.lib.pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
 
     mtx = general_transform_matrix([v.sizeX(), v.sizeY(), v.sizeZ()], rot=rot, shift=shift, scale=scale, order=order,
                                    center=center)
@@ -530,7 +530,7 @@ def general_transform(v, rot=None, shift=None, scale=None, order=[0, 1, 2], cent
 def general_transform2d(v, rot=None, shift=None, scale=None, order=[0, 1, 2], crop=True, center=None ):
     """Perform general transformation of 2D data using 3rd order spline interpolation.
     @param v: volume in 2d (it's got to be an image)
-    @type v: L{pytom_volume.vol}
+    @type v: L{pytom.lib.pytom_volume.vol}
     @param rot: rotate
     @type rot: float
     @param shift: shift
@@ -544,16 +544,16 @@ def general_transform2d(v, rot=None, shift=None, scale=None, order=[0, 1, 2], cr
     @type crop: boolean
     @param center: optional list with center coordinates in pixels
     @type center: list of 3 floats
-    @return: pytom_volume
+    @return: pytom.lib.pytom_volume
     """
     from pytom.basic.structures import Shift
 
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     if not isinstance(v,vol):
         if isinstance(v,tuple) and isinstance(v[0],vol):
             v = v[0]
         else:
-            raise TypeError('general_transform2d: v must be of type pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
+            raise TypeError('general_transform2d: v must be of type pytom.lib.pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
     if v.sizeZ() != 1:
         raise RuntimeError('general_transform2d: v must be 2D!')
     if rot is None:
@@ -578,22 +578,22 @@ def project(v, rot, verbose=False):
     """
     rotate and subsequently project volume along z
     @param v: volume
-    @type v: L{pytom_volume.vol}
+    @type v: L{pytom.lib.pytom_volume.vol}
     @param rot: rotation - either Rotation object or single angle interpreted as rotation along y-axis
     @type rot: L{pytom.basic.structures.Rotation} or float
     @return: projection (2D image)
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
-    from pytom_volume import vol
-    from pytom_numpy import vol2npy, npy2vol
+    from pytom.lib.pytom_volume import vol
+    from pytom.lib.pytom_numpy import vol2npy, npy2vol
     from numpy import ndarray, float32
     from pytom.basic.transformations import general_transform_crop
     from pytom.basic.structures import Rotation
     from numpy import sum as proj
 
     if not isinstance(v, vol):
-        raise TypeError('project: v must be of type pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
+        raise TypeError('project: v must be of type pytom.lib.pytom_volume.vol! Got ' + str(v.__class__) + ' instead!')
     if isinstance(rot, float):
         rot = Rotation(z1=90., z2=270., x=rot, paradigm='ZXZ')
     if not isinstance(rot, Rotation):

--- a/pytom/gui/guiFunctions.py
+++ b/pytom/gui/guiFunctions.py
@@ -4,10 +4,10 @@ import mrcfile
 import copy
 
 # pytom imports
-from pytom_volume import read
+from pytom.lib.pytom_volume import read
 from pytom.basic.files import read_em_header
 from pytom.gui.mrcOperations import read_mrc, read_angle
-from pytom_numpy import vol2npy
+from pytom.lib.pytom_numpy import vol2npy
 from pytom.gui.guiSupportCommands import multiple_alignment
 from pytom.basic.files import loadtxt as loadstar, savetxt as savestar
 
@@ -156,7 +156,7 @@ def readMarkerfile(filename, num_tilt_images=0):
 
     if filename.endswith('.em'):
         from pytom.basic.files import read
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
         markerfile = read(filename)
         markerdata = vol2npy(markerfile).copy()
         return markerdata

--- a/pytom/pytomc/installFunctions.py
+++ b/pytom/pytomc/installFunctions.py
@@ -206,14 +206,12 @@ def generateExecuteables(libPaths=None,binPaths=None,pyPaths=None,python_version
     os.chdir(pytomDirectory + os.sep + 'pytomc')
     generatePyTomScript(pytomDirectory, python_version)
     generateIPyTomScript(pytomDirectory)
-    generatePathsFile(pytomDirectory,libPaths,binPaths,pyPaths)
     generatePyTomGuiScript(pytomDirectory, python_version)
 
 def generatePyTomScript(pytomDirectory,python_version):
     
     pytomCommand = f"""#!/usr/bin/env bash
 cat {sys.prefix}/pytom_data/LICENSE.txt
-source {pytomDirectory}/bin/paths.sh
 
 FID=0
 export PYTOM_GPU=-1
@@ -254,7 +252,6 @@ def generateIPyTomScript(pytomDirectory):
 
     ipytomCommand = '#!/usr/bin/env bash\n'
     ipytomCommand += f'cat {sys.prefix}/pytom_data/LICENSE.txt\n'
-    ipytomCommand += 'source ' + pytomDirectory + os.sep + 'bin' + os.sep + 'paths.sh\n'
     ipytomCommand += 'ipython $* -i\n'
     
     f = open(pytomDirectory + os.sep + 'bin' + os.sep + 'ipytom','w')
@@ -263,44 +260,6 @@ def generateIPyTomScript(pytomDirectory):
     
     os.system('chmod 755 ' + pytomDirectory + os.sep + 'bin' + os.sep + 'ipytom')
 
-def generatePathsFile(pytomDirectory,libPaths, binPaths, pyPaths):
-        os.chdir(pytomDirectory + os.sep + '..')
-        oneAbove = os.getcwd()
-        os.chdir(pytomDirectory)
-        
-        libString = ''
-        
-        if libPaths.__class__ == list and len(libPaths) > 0:
-            for lib in libPaths:
-                if not lib == None and lib.__class__ == str:
-                    libString += lib + ':'
-        
-        pyString = ''
-        if pyPaths.__class__ == list and len(pyPaths) > 0:
-            for p in pyPaths:
-                if p is not None:
-                    pyString += p + ':'
-        
-        cshCommands  = '#!/usr/bin/env bash\n'
-        cshCommands += "export LD_LIBRARY_PATH='" + libString + pytomDirectory + os.sep +  "lib':$LD_LIBRARY_PATH\n"
-
-        if binPaths.__class__ == list and len(binPaths) > 0:    
-
-            binString = ''
-            
-            for bin in binPaths:
-                if not bin == None:
-                    binString += bin +':'
-            binString = binString[0:-1]
-             
-            cshCommands += "export PATH='" + binString + ":" + pytomDirectory + os.sep + 'convert' + os.sep + ":" + pytomDirectory + os.sep + 'lib'  + "':$PATH\n"
-                        
-        cshCommands += "export PYTHONPATH='" + pyString + oneAbove + ":" + pytomDirectory + os.sep + "lib':$PYTHONPATH\n"
-
- 
-        f = open(pytomDirectory + os.sep + 'bin' + os.sep + 'paths.sh','w')
-        f.write(cshCommands)
-        f.close()
     
 def checkCompileDirsExist():
     

--- a/pytom/reconstruction/imageStructures.py
+++ b/pytom/reconstruction/imageStructures.py
@@ -6,7 +6,7 @@ started on Feb 02, 2013
 
 
 from pytom.basic.structures import PyTomClass
-from pytom_volume import vol
+from pytom.lib.pytom_volume import vol
 
 class Image(PyTomClass):
     """
@@ -36,7 +36,7 @@ class Image(PyTomClass):
         @type index: L{int}
         """
         self.verbose = verbose
-        from pytom_volume import read, vol
+        from pytom.lib.pytom_volume import read, vol
         if filename:
             self.read(filename=filename, boxCoords=boxCoords, dims=dims)
         else:
@@ -61,7 +61,7 @@ class Image(PyTomClass):
         @param dims: dimensions of subframe
         @type dims: 2-dim or 3-dim list
         """
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
 
         self.data = read(filename, int(boxCoords[0]), int(boxCoords[1]), int(boxCoords[2]),
                          int(dims[0]), int(dims[1]), int(dims[2]), 0, 0, 0, 1, 1, 1)
@@ -114,7 +114,7 @@ class Image(PyTomClass):
             # user-specified generic mask
             else:
                 if type(mask) != vol:
-                    raise TypeError("Mask must be pytom_volume.vol")
+                    raise TypeError("Mask must be pytom.lib.pytom_volume.vol")
                 if ((mask.sizeX() != self.data.sizeX()) or
                         (mask.sizeY() != self.data.sizeY()) or
                         (mask.sizeZ() != self.data.sizeZ())):
@@ -138,9 +138,9 @@ class Image(PyTomClass):
         @param width: width of tapered edge
         @type width: L{float} or L{int}
         @param taper_mask: mask for tapering - if None it will be generated
-        @type taper_mask: L{pytom_volume.vol}
+        @type taper_mask: L{pytom.lib.pytom_volume.vol}
         @return: taper_mask
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
         from pytom.basic.functions import taper_edges
 
@@ -270,7 +270,7 @@ class ImageStack(PyTomClass):
         @param filename: name of stack
         @type filename: L{str}
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
 
         stack = vol(self.dimX, self.dimY, len(self.images))
         for ii in range(0, len(self.images)):
@@ -287,7 +287,7 @@ class ImageStack(PyTomClass):
         @param filename: name of stack
         @type filename: L{str}
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
 
         stack = vol(self.dimX, self.dimY, len(self.images))
         for ii in range(0, len(self.images)):
@@ -302,9 +302,9 @@ class ImageStack(PyTomClass):
         average Image Stack
 
         @param mask: mask is multiplied with average if specified
-        @type mask: L{pytom_volume.vol}
+        @type mask: L{pytom.lib.pytom_volume.vol}
         @return: average
-        @rtype: L{ptom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
         from pytom.basic.transformations import general_transform2d
 
@@ -337,9 +337,9 @@ class ImageStack(PyTomClass):
         @param ii: index of image to be subtracted
         @type ii: L{int}
         @param mask: mask is multiplied with average if specified
-        @type mask: L{pytom_volume.vol}
+        @type mask: L{pytom.lib.pytom_volume.vol}
         @return: average of remaining images
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
         av = vol(self.dimX, self.dimY, 1)
         av.copyVolume(self.averageData)
@@ -356,11 +356,11 @@ class ImageStack(PyTomClass):
         @param niter: number of iterations
         @type niter: L{int}
         @param mask: mask applied to average before alignment
-        @type mask: L{pytom_volume.vol}
+        @type mask: L{pytom.lib.pytom_volume.vol}
         @author: FF
         """
         from pytom.basic.correlation import nXcf, subPixelPeak
-        from pytom_volume import peak
+        from pytom.lib.pytom_volume import peak
 
         for iexMax in range(0, niter):
             if self.verbose:
@@ -396,7 +396,7 @@ class ImageStack(PyTomClass):
         @param normtype: normalization type
         @type normtype: str ("StdMeanInMask", )
         @param mask: mask used for normalization
-        @type mask: L{pytom_volume.vol}
+        @type mask: L{pytom.lib.pytom_volume.vol}
         """
         for ii in range(0, len(self.images)):
             self.p = self.images[ii].normalize(normtype=normtype, mask=mask,
@@ -410,10 +410,10 @@ class ImageStack(PyTomClass):
         @param width: width of tapered edge
         @type width: L{float} or L{int}
         @param taper_mask: mask for tapering - if None it will be generated
-        @type taper_mask: L{pytom_volume.vol}
+        @type taper_mask: L{pytom.lib.pytom_volume.vol}
 
         @return taper_mask
-        @rtype: L{pytom_volume.vol}
+        @rtype: L{pytom.lib.pytom_volume.vol}
         """
         for ii in range(0, len(self.images)):
             taper_mask = self.images[ii].taper_edges(width=width, taper_mask=taper_mask)

--- a/pytom/simulation/SimpleSubtomogram.py
+++ b/pytom/simulation/SimpleSubtomogram.py
@@ -10,7 +10,7 @@ def simpleSimulation(volume,rotation,shiftV,wedgeInfo=None,SNR=0.1,mask=None):
     @param mask: Apodisation mask 
     @return: a simple cryo em simulation of volume 
     """
-    from pytom_volume import vol,rotate,shift,initSphere
+    from pytom.lib.pytom_volume import vol,rotate,shift,initSphere
     from pytom.simulation.support import add_white_noise
     
     if not rotation == [0,0,0]:

--- a/pytom/simulation/support.py
+++ b/pytom/simulation/support.py
@@ -334,7 +334,7 @@ def add_white_noise(volume, SNR=1):
         return volume
 
     from math import sqrt
-    from pytom_volume import vol, mean, variance, gaussianNoise
+    from pytom.lib.pytom_volume import vol, mean, variance, gaussianNoise
 
     m = mean(volume)
     s = sqrt(variance(volume, False) / SNR)  # SNR = Var(signal) / Var(noise)

--- a/pytom/tools/maths.py
+++ b/pytom/tools/maths.py
@@ -196,7 +196,7 @@ class Matrix(object):
         @param sizeY: size in Z
         @type sizeY: int
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         
         if sizeX.__class__ == vol:
             self._matrix = sizeX
@@ -457,10 +457,10 @@ def pcacov(matrix):
     from numpy import sum,max,diag
     from scipy.linalg import svd
     
-    from pytom_volume import vol
+    from pytom.lib.pytom_volume import vol
     
     if matrix.__class__ == vol:
-        from pytom_numpy import vol2npy
+        from pytom.lib.pytom_numpy import vol2npy
         matrix = vol2npy(matrix)
     
     [x,latent,coeff] = svd(matrix)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install
 
 import subprocess
@@ -27,11 +27,10 @@ class CustomInstall(install):
         process = subprocess.Popen(commandInstall, shell=True, cwd="pytom/pytomc")
         process.wait()
         install.run(self)
-
 setup(
     name='pytom',
     version=__version__,
-    packages=find_packages(),
+    packages=find_namespace_packages(include=['pytom*']),
     package_dir={'pytom':'pytom'},
     package_data={'pytom/angles/angleLists': find_angle_lists('pytom/angles/angleLists')},
     data_files=[("pytom_data", ["./LICENSE.txt"])], # This is a relative dir to sys.prefix

--- a/tests/test_AngleTest.py
+++ b/tests/test_AngleTest.py
@@ -29,7 +29,7 @@ class pytom_AngleTest(unittest.TestCase):
     
     def test_AngleEMList_focusRotation(self):
         from pytom.angles.globalSampling import GlobalSampling
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         import os
         
         v = vol(3,2,1)

--- a/tests/test_FilterTest.py
+++ b/tests/test_FilterTest.py
@@ -9,11 +9,10 @@ class pytom_FilterTest(unittest.TestCase):
         """
         test wedge filter functions and their consistency
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol, complexRealMult
         from pytom.basic.structures import WedgeInfo,Rotation,Shift
         from pytom.basic.filter import filter
         from pytom.basic.fourier import fft, ifft
-        from pytom_volume import complexRealMult
 
         v = vol(32,32,32)
         v.setAll(0.0)
@@ -36,11 +35,9 @@ class pytom_FilterTest(unittest.TestCase):
     def test_wedgeRotation(self):
         """
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol, rotate, complexRealMult
         from pytom.basic.structures import Wedge, Rotation
-        from pytom_volume import rotate
         from pytom.basic.fourier import fft, ifft
-        from pytom_volume import complexRealMult
         from pytom.basic.filter import rotateWeighting
 
         dim = 24
@@ -83,7 +80,7 @@ class pytom_FilterTest(unittest.TestCase):
         """
         Why is this one here?
         """
-        import pytom_volume
+        import pytom.lib.pytom_volume as pytom_volume
         from pytom.basic import correlation
         s = pytom_volume.vol(32,32,32)
         s2 = pytom_volume.vol(32,32,32)
@@ -101,7 +98,7 @@ class pytom_FilterTest(unittest.TestCase):
 
     def test_bandpassFilter(self):
 
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from pytom.basic.filter import bandpassFilter
 
         refNoise = vol(64,64,64)
@@ -122,9 +119,9 @@ class pytom_FilterTest(unittest.TestCase):
         """
 	    output of filtering should be almost equal to input
         """
-        import pytom_volume
+        import pytom.lib.pytom_volume as pytom_volume
         from pytom.basic.filter import filter
-        from pytom_freqweight import weight
+        from pytom.lib.pytom_freqweight import weight
         
         vol1 = pytom_volume.vol(64,64,64)
         vol2 = pytom_volume.vol(64,64,64)
@@ -148,7 +145,7 @@ class pytom_FilterTest(unittest.TestCase):
         """
         output of ramp filtering
         """
-        from pytom_volume import vol, complexRealMult, peak
+        from pytom.lib.pytom_volume import vol, complexRealMult, peak
         from pytom.basic.filter import filter as fil
         from pytom.basic.filter import circleFilter,rampFilter,fourierFilterShift
         from pytom.basic.fourier import fft,ifft
@@ -188,7 +185,7 @@ class pytom_FilterTest(unittest.TestCase):
         os.system('rm weiproj.em')
         
     def test_complexDiv(self):
-        from pytom_volume import vol, complexDiv,abs,peak
+        from pytom.lib.pytom_volume import vol, complexDiv,abs,peak
         from pytom.basic.fourier import fft,ifft
         
         v = vol(64,64,64)
@@ -218,7 +215,7 @@ class pytom_FilterTest(unittest.TestCase):
         """test filter by 1-d profile"""
         from pytom.basic.filter import profile2FourierVol
         from pytom.basic.fourier import convolute, powerspectrum
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from math import sqrt
         
         #generate radial Fourier Filter

--- a/tests/test_InteroplationTest.py
+++ b/tests/test_InteroplationTest.py
@@ -2,7 +2,7 @@ import unittest, os, numba
 import numpy as np
 import pytom.voltools as vt
 import time
-from pytom_volume import vol, transform, transformCubic, transformSpline, transformFourierSpline, variance
+from pytom.lib.pytom_volume import vol, transform, transformCubic, transformSpline, transformFourierSpline, variance
 from pytom.agnostic.interpolation import fill_values_real_spline, fill_values_real_spline_parallel
 
 

--- a/tests/test_MPITest.py
+++ b/tests/test_MPITest.py
@@ -23,7 +23,7 @@ class pytom_MPITest(unittest.TestCase):
         print(runMPI)
         self.testCommand = runMPI + ' -c 2 pytom testScript.py'
          
-        testScript  = 'from pytom_mpi import rank,init,isInitialised,finalise \n'
+        testScript  = 'from pytom.lib.pytom_mpi import rank,init,isInitialised,finalise \n'
         testScript += 'import os\n'
         testScript += 'init()\n'
         testScript += 'os.system("echo " +str(rank())+ " > " +str(rank())+ ".rnkPyTom" )\n'

--- a/tests/test_MathTest.py
+++ b/tests/test_MathTest.py
@@ -78,7 +78,7 @@ class pytom_MathTest(unittest.TestCase):
                     msg='Rotation incorrect')
     
     def test_Pcacov(self):
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from pytom.tools.maths import pcacov
         from numpy import zeros,sum
         

--- a/tests/test_NormTest.py
+++ b/tests/test_NormTest.py
@@ -6,7 +6,7 @@ class pytom_NormTest(unittest.TestCase):
     
     def mean0std1_Test(self):
 
-        import pytom_volume
+        import pytom.lib.pytom_volume as pytom_volume
         from pytom.basic.normalise import mean0std1
         from helper_functions import create_RandomParticleList, installdir
 
@@ -21,7 +21,7 @@ class pytom_NormTest(unittest.TestCase):
         assert 1+epsilon >= var >= 1-epsilon
 
     def zeroVol_Test(self):
-        import pytom_volume
+        import pytom.lib.pytom_volume as pytom_volume
         from pytom.basic.normalise import normaliseUnderMask
         #from pytom_volume import vol, initSphere
 

--- a/tests/test_NumpyTest.py
+++ b/tests/test_NumpyTest.py
@@ -5,8 +5,8 @@ Created on Jan 12, 2022
 """
 import unittest
 import numpy as np
-from pytom_volume import vol, gaussianNoise
-import pytom_numpy
+from pytom.lib.pytom_volume import vol, gaussianNoise
+import pytom.lib.pytom_numpy as pytom_numpy
 
 
 class pytom_NumpyTest(unittest.TestCase):

--- a/tests/test_RotationTest.py
+++ b/tests/test_RotationTest.py
@@ -10,7 +10,7 @@ import pytom.voltools as vt
 from pytom.basic.structures import Rotation
 from pytom.angles.angleFnc import matToZXZ
 from math import modf
-from pytom_numpy import vol2npy, npy2vol
+from pytom.lib.pytom_numpy import vol2npy, npy2vol
 from pytom.agnostic.tools import rotation_matrix, convert_angles, mat2ord
 from scipy.ndimage import affine_transform
 from pytom.agnostic.correlation import nxcc

--- a/tests/test_ScoreTest.py
+++ b/tests/test_ScoreTest.py
@@ -4,7 +4,7 @@ class pytom_ScoreTest(unittest.TestCase):
     
     def setUp(self):
         """set up"""
-        from pytom_volume import vol, initSphere
+        from pytom.lib.pytom_volume import vol, initSphere
         from pytom.basic.structures import WedgeInfo
         from pytom.simulation.SimpleSubtomogram import simpleSimulation
 
@@ -25,7 +25,7 @@ class pytom_ScoreTest(unittest.TestCase):
 
     def test_xcfScore(self):
         from pytom.basic.score import xcfScore as score
-        from pytom_volume import peak
+        from pytom.lib.pytom_volume import peak
 
         sc = score()
         # consistency of scoring coefficient and scoring function - difference 
@@ -45,7 +45,7 @@ class pytom_ScoreTest(unittest.TestCase):
         test nxcf score
         """
         from pytom.basic.score import nxcfScore as score
-        from pytom_volume import peak
+        from pytom.lib.pytom_volume import peak
 
         sc = score()
         # check auto-correlation coefficient
@@ -79,7 +79,7 @@ class pytom_ScoreTest(unittest.TestCase):
         test FLCF score
         """
         from pytom.basic.score import FLCFScore as score
-        from pytom_volume import peak
+        from pytom.lib.pytom_volume import peak
         
         sc = score()
         # check auto-correlation coefficient
@@ -99,7 +99,7 @@ class pytom_ScoreTest(unittest.TestCase):
         second order correlation score
         """
         from pytom.basic.score import SOCScore as score
-        from pytom_volume import peak
+        from pytom.lib.pytom_volume import peak
 
         sc = score()
         # check auto-correlation coefficient

--- a/tests/test_TransformationTest.py
+++ b/tests/test_TransformationTest.py
@@ -1,5 +1,5 @@
 import unittest
-from pytom_volume import vol
+from pytom.lib.pytom_volume import vol
 from numpy import array
 from pytom.basic.transformations import general_transform2d
 from pytom.tools.maths import rotate_vector
@@ -59,7 +59,7 @@ class pytom_TransformationTest(unittest.TestCase):
         test re-sizing in Fourier space
         """
         from pytom.basic.transformations import resize
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from pytom.basic.fourier import fft
 
         dim = 32
@@ -78,7 +78,7 @@ class pytom_TransformationTest(unittest.TestCase):
                 diff = ftresizeVol.getV(ix,iy,0) - scf*4*resizefVol.getV(ix,iy,0)
                 self.assertTrue(expr=abs(diff) < .05, msg="inconsistency FFT/IFFT for magnification")
         (resizeVol, resizefVol) = resize(volume=resizeVol, factor=.5, interpolation='Fourier')
-        from pytom_volume import variance
+        from pytom.lib.pytom_volume import variance
         diff = myVol - resizeVol
         self.assertTrue(expr=variance(diff, False) < .0000001, msg="2D image before and after rescales differs")
 
@@ -88,7 +88,7 @@ class pytom_TransformationTest(unittest.TestCase):
         test 3D re-sizing in Fourier space
         """
         from pytom.basic.transformations import resize
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
 
         dim = 32
         px = 11
@@ -99,7 +99,7 @@ class pytom_TransformationTest(unittest.TestCase):
         myVol.setV(1., px, py, pz)
         (resizeVol, resizefVol) = resize(volume=myVol, factor=2., interpolation='Fourier')
         (resizeVol, resizefVol) = resize(volume=resizeVol, factor=.5, interpolation='Fourier')
-        from pytom_volume import variance
+        from pytom.lib.pytom_volume import variance
         diff = myVol - resizeVol
         self.assertTrue(expr=variance(diff, False) < .0000001, msg="2D image before and after rescales differs")
 

--- a/tests/test_WedgeTest.py
+++ b/tests/test_WedgeTest.py
@@ -8,7 +8,7 @@ import numpy as np
 from pytom.basic.structures import Wedge, Rotation
 from pytom.agnostic.correlation import nxcc
 from pytom.agnostic.structures import Wedge as WedgeNp
-from pytom_numpy import vol2npy
+from pytom.lib.pytom_numpy import vol2npy
 
 
 class pytom_NumpyTest(unittest.TestCase):


### PR DESCRIPTION
This removes the installation of  'path.sh' and then fixes the rest of the code.

 The fix is mostly is adding `pytom.lib` in front of all imports of `pytom_*` such as `pytom_volume`, `pytom_mpi` etc..

This was only fixed for code that I could actually run tests on, but if there is code that is broken due to this the solution should be quite simple
