### PR TITLE
fixed missing argument in call to popup_messagebox() in particle picking gui frame

### DIFF
--- a/pytom/gui/frameParticlePicking.py
+++ b/pytom/gui/frameParticlePicking.py
@@ -573,8 +573,9 @@ class ParticlePick(GuiTabWidget):
 
                     # check number of splits is not larger than number of gpus
                     if gpuIDFlag and len(list(map(int, gpuID.split(',')))) < splitx * splity * splitz:
-                        self.popup_messagebox('Warning', 'Number of gpus is less than the number of subvolumes a '
-                                                         'tomogram is split into, this will crash.')
+                        self.popup_messagebox('Warning', 'Parameter issue',
+                                              'Number of gpus is less than the number of subvolumes a '
+                                              'tomogram is split into, this will crash.')
                         return
 
                     fname = 'TM_Batch_ID_{}'.format(num_submitted_jobs % num_nodes)


### PR DESCRIPTION
This is a fix for issue 113. Only added a missing parameter to a function call.

(added by sander):
closes #113 