### PR TITLE
include kernels for pytom/voltools correctly in setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include pytom/lib/*.so
 include pytom/lib/*.py
+include pytom/voltools/kernels/*.h
 include pytom/bin/pytom
 include pytom/bin/ipytom
 include pytom/bin/pytomGUI

--- a/pytom/gui/frameParticlePicking.py
+++ b/pytom/gui/frameParticlePicking.py
@@ -573,8 +573,9 @@ class ParticlePick(GuiTabWidget):
 
                     # check number of splits is not larger than number of gpus
                     if gpuIDFlag and len(list(map(int, gpuID.split(',')))) < splitx * splity * splitz:
-                        self.popup_messagebox('Warning', 'Number of gpus is less than the number of subvolumes a '
-                                                         'tomogram is split into, this will crash.')
+                        self.popup_messagebox('Warning', 'Parameter issue',
+                                              'Number of gpus is less than the number of subvolumes a '
+                                              'tomogram is split into, this will crash.')
                         return
 
                     fname = 'TM_Batch_ID_{}'.format(num_submitted_jobs % num_nodes)

--- a/tests/test_InteroplationTest.py
+++ b/tests/test_InteroplationTest.py
@@ -113,6 +113,14 @@ class pytom_InterpolationTest(unittest.TestCase):
     @unittest.skipIf(os.environ.get('AM_I_IN_A_DOCKER_CONTAINER', False),
                      "The test below uses multiple cores and cannot execute in a docker environment")
     def test_numba_interpolation_parallel(self):
+        """
+        This currently report the following deprecation warning in openMP. This has to do with how numba calls
+        openMP, so it is not easily fixable for us.
+
+        ###############################
+        .OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.
+        ###############################
+        """
         print('before parallel: ', numba.get_num_threads())
         numba.set_num_threads(4)
         print('after setting for parallel: ', numba.get_num_threads())


### PR DESCRIPTION
Voltools could not transform with custom cuda kernels because they were not included during installation. I added an include statement to the MANIFEST to fix it.