### PR TITLE
fix for e2e-test for glocal subtomogram alignment 

### DIFF
--- a/pytom/alignment/ExMaxAlignment.py
+++ b/pytom/alignment/ExMaxAlignment.py
@@ -346,7 +346,7 @@ class ExMaxJob(PyTomClass):
         """
         
         from pytom.tools.files import checkFileExists,checkDirExists
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         
         self._particleList.check()
         
@@ -385,7 +385,7 @@ class ExMaxWorker(object):
         @param verbose: Print debug messages (False by default) 
         """
     
-        import pytom_mpi
+        import pytom.lib.pytom_mpi as pytom_mpi
         from pytom.parallel.alignmentMessages import MaximisationJobMsg,MaximisationResultMsg,ExpectationJobMsg,ExpectationResultMsg
         from pytom.parallel.messages import StatusMessage,MessageError
         from pytom.basic.exceptions import ParameterError
@@ -488,7 +488,7 @@ class ExMaxWorker(object):
         
         
         if self._particle.__class__ == Particle:
-            from pytom_volume import read
+            from pytom.lib.pytom_volume import read
             particleFile    = self._particle.getFilename()
             # changed FF: binning now solely done in bestAlignment
             particle        = read(particleFile,0,0,0,0,0,0,0,0,0,
@@ -520,7 +520,7 @@ class ExMaxWorker(object):
             referenceObject = self._reference
         else:
             if self._reference.__class__ == Reference:
-                from pytom_volume import read
+                from pytom.lib.pytom_volume import read
                 referenceObject     = self._reference
                 referenceFile       = self._reference.getReferenceFilename()
                 # changed FF: binning only in bestAlignment function
@@ -530,10 +530,10 @@ class ExMaxWorker(object):
            
             if self._referenceWeighting == str and len(self._referenceWeighting) > 0:
                 # changed FF: binning only in bestAlignment function
-                from pytom_volume import read
+                from pytom.lib.pytom_volume import read
                 self._referenceWeighting        = read(self._referenceWeighting)
                 #if self._binning == 1:
-                #    from pytom_volume import read
+                #    from pytom.lib.pytom_volume import read
                 #    self._referenceWeighting        = read(self._referenceWeighting)
                 #else:
                 #    from pytom.basic.files import readSubvolumeFromFourierspaceFile
@@ -688,7 +688,7 @@ class ExMaxManager(PyTomClass):
         distributeAlignment: Distribute job in worker pool
         """
         
-        import pytom_mpi
+        import pytom.lib.pytom_mpi as pytom_mpi
         from pytom.alignment.structures import MaximisationJob,ExpectationJob
         from pytom.tools.files import checkFileExists,checkDirExists
         from pytom.parallel.alignmentMessages import MaximisationJobMsg,MaximisationResultMsg
@@ -843,7 +843,7 @@ class ExMaxManager(PyTomClass):
         parallelEnd : Sends status message = end to all workers. All workers will terminate upon receiving this message.
         @author: Thomas Hrabe
         """
-        import pytom_mpi
+        import pytom.lib.pytom_mpi as pytom_mpi
         from pytom.parallel.messages import StatusMessage
         
         mpi_numberNodes = pytom_mpi.size()
@@ -863,7 +863,7 @@ class ExMaxManager(PyTomClass):
         @author: Thomas Hrabe
         """
         from pytom.basic.correlation import FSC,determineResolution
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom.basic.score import RScore
         self._saveForFSC(self._destination + filename)
         
@@ -898,7 +898,7 @@ def parallelStart(exMaxJob,verbose,sendFinishMessage = True):
     from pytom.basic.structures import Reference
     mpiWorks = True
     try: 
-        import pytom_mpi
+        import pytom.lib.pytom_mpi as pytom_mpi
     
         if not pytom_mpi.isInitialised():
             if verbose:
@@ -916,7 +916,7 @@ def parallelStart(exMaxJob,verbose,sendFinishMessage = True):
     if pytom_mpi.size() >1:
         
         if mpi_myid == 0:
-            from pytom_volume import read
+            from pytom.lib.pytom_volume import read
             from pytom.basic.filter import lowpassFilter
             from pytom.alignment.alignmentFunctions import _disrtibuteAverageMPI,alignmentProgressToHTML
             
@@ -1100,7 +1100,7 @@ def sequentialStart(exMaxJob,verbose,sendFinishMessage = True):
     @param sendFinishMessage: Send finish message to worker nodes. True by default, False for multi ref alignment for instance 
     """
         
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
     from pytom.basic.filter import lowpassFilter
     from pytom.alignment.alignmentFunctions import average,alignmentProgressToHTML
     from pytom.alignment.structures import AlignmentList

--- a/pytom/alignment/FRMAlignment.py
+++ b/pytom/alignment/FRMAlignment.py
@@ -6,7 +6,7 @@ Created on Mar 5, 2012
 '''
 
 from pytom.basic.structures import PyTomClass
-import pytom_mpi
+import pytom.lib.pytom_mpi as pytom_mpi
 import os
 
 class FRMJob(PyTomClass): # i need to rename the class, but for now it works
@@ -532,7 +532,7 @@ class FRMWorker():
            @param name_prefix: name prefix output densities
            @type name_prefix: C{str}
         """
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         even_pre = read(name_prefix+'even'+'-PreWedge.em')
         even_wedge = read(name_prefix+'even'+'-WedgeSumUnscaled.em')
         odd_pre = read(name_prefix+'odd'+'-PreWedge.em')
@@ -557,13 +557,13 @@ class FRMWorker():
     def create_average(self, pre, wedge):
         """For the master node, create the average according to the pre-wedge and wedge volumes.
            @param pre: density prior to weighting
-           @type pre: L{pytom_volume.vol}
+           @type pre: L{pytom.lib.pytom_volume.vol}
            @param wedge: wedge 
            @type wedge: L{pytom.basic.Wedge}
            @return: wedge-weighted density
-           @rtype: L{pytom_volume.vol}
+           @rtype: L{pytom.lib.pytom_volume.vol}
         """
-        from pytom_volume import complexDiv, limit
+        from pytom.lib.pytom_volume import complexDiv, limit
         from pytom.basic.fourier import fft,ifft
         
         limit(wedge, 0.1, 0, 0,0,True,False) # set all the values below the specified value to 0

--- a/pytom/alignment/GFRMAlignment.py
+++ b/pytom/alignment/GFRMAlignment.py
@@ -5,7 +5,7 @@ Created on Sep 3, 2012
 '''
 
 from pytom.basic.structures import PyTomClass
-import pytom_mpi
+import pytom.lib.pytom_mpi as pytom_mpi
 import os
 
 class FRMJob(PyTomClass): # i need to rename the class, but for now it works
@@ -279,10 +279,10 @@ class FRMWorker():
                 print(self.node_name + 'Transform of even set to match the odd set - shift: '+str(pos)+' rotation: '+str(angle))
                 
                 # transform the odd set accordingly
-                from pytom_volume import vol, transformSpline
+                from pytom.lib.pytom_volume import vol, transformSpline
                 from pytom.basic.fourier import ftshift
-                from pytom_volume import reducedToFull
-                from pytom_freqweight import weight
+                from pytom.lib.pytom_volume import reducedToFull
+                from pytom.lib.pytom_freqweight import weight
                 transformed_odd_pre = vol(odd.sizeX(), odd.sizeY(), odd.sizeZ())
                 full_all_odd_wedge = reducedToFull(all_odd_wedge)
                 ftshift(full_all_odd_wedge)
@@ -422,7 +422,7 @@ class FRMWorker():
     def retrieve_res_vols(self, name_prefix):
         """For master node, retrieve the sub-averages and do the cleaning.
         """
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         pre = read(name_prefix+'-PreWedge.em')
         wedge = read(name_prefix+'-WedgeSumUnscaled.em')
         
@@ -440,7 +440,7 @@ class FRMWorker():
     def create_average(self, pre, wedge):
         """For the master node, create the average according to the pre-wedge and wedge volumes.
         """
-        from pytom_volume import complexDiv, limit
+        from pytom.lib.pytom_volume import complexDiv, limit
         from pytom.basic.fourier import fft,ifft
         
         limit(wedge, 0.1, 0, 0,0,True,False) # set all the values below the specified value to 0

--- a/pytom/alignment/GLocalSampling.py
+++ b/pytom/alignment/GLocalSampling.py
@@ -154,7 +154,7 @@ def mainAlignmentLoop(alignmentJob, verbose=False):
                             numberOfBands=len(fsc), upscale=1)
             # read un-corrected averages back in for compoundWedge
             if alignmentJob.scoringParameters.compoundWedge:
-                from pytom_volume import read
+                from pytom.lib.pytom_volume import read
                 averageEven = read(alignmentJob.destination+"/"+str(ii)+f'-EvenFiltered-PreWedge.{filetype}')
                 averageOdd  = read(alignmentJob.destination+"/"+str(ii)+f'-OddFiltered-PreWedge.{filetype}')
                 evenCompoundWedgeFile = alignmentJob.destination+"/"+str(ii)+f"-EvenFiltered-WedgeSumUnscaled.{filetype}"
@@ -495,7 +495,7 @@ def alignParticleList(pl, reference, referenceWeightingFile, rotationsFilename,
     @type pl: L{pytom.basic.structures.ParticleList}
     #@param particleFilename:
     @param reference: reference volume
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param referenceWeightingFile: File for Fourier weighting of the reference (sum of wedges for instance) = CompoundWedge
     @type referenceWeightingFile: str
     @param rotationsFilename: name of rotations xml file
@@ -528,7 +528,7 @@ def alignParticleList(pl, reference, referenceWeightingFile, rotationsFilename,
     mask.fromXMLFile(filename=maskFilename)
 
     if referenceWeightingFile:
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         referenceWeighting = read(referenceWeightingFile)
     else:
         referenceWeighting = None
@@ -559,7 +559,7 @@ def alignParticleListGPU(pl, reference, referenceWeightingFile, rotationsFilenam
     @type pl: L{pytom.basic.structures.ParticleList}
     #@param particleFilename:
     @param reference: reference volume
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param referenceWeightingFile: File for Fourier weighting of the reference (sum of wedges for instance) = CompoundWedge
     @type referenceWeightingFile: str
     @param rotationsFilename: name of rotations xml file
@@ -608,8 +608,10 @@ def alignParticleListGPU(pl, reference, referenceWeightingFile, rotationsFilenam
     if verbose:
         print("alignParticleList: rank "+str(mpi.rank))
         print("alignParticleList: angleObject: "+str(rotations))
-        print("alignParticleList: scoreObject: "+str(scoreObject))
         print("alignParticleList: mask:        "+str(mask))
+
+        # scoreobject is not needed for GPU?
+        # print("alignParticleList: scoreObject: "+str(scoreObject))
 
     bestPeaks = []
     for n, particle in enumerate(pl):
@@ -627,11 +629,11 @@ def alignParticleListGPU(pl, reference, referenceWeightingFile, rotationsFilenam
         particle.setShift(bestPeak.getShift())
         angDiff = differenceAngleOfTwoRotations(rotation1=bestPeak.getRotation(), rotation2=oldRot)
         t2 = time()  # end time after alignment
-        # if verbose:
-        shifts_print = bestPeak.getShift().toVector()
-        print(f"{fname}: Angular diff before and after alignment {angDiff:2.2f} and shift "
-              f"{shifts_print[0]:.4f}, {shifts_print[1]:.4f}, {shifts_print[2]:.4f}... "
-              f"took {t2-t1:3.1f} seconds...")
+        if verbose:
+            shifts_print = bestPeak.getShift().toVector()
+            print(f"{fname}: Angular diff before and after alignment {angDiff:2.2f} and shift "
+                  f"{shifts_print[0]:.4f}, {shifts_print[1]:.4f}, {shifts_print[2]:.4f}... "
+                  f"took {t2-t1:3.1f} seconds...")
 
     plan.clean()
     return [bestPeaks, plan]
@@ -646,7 +648,7 @@ def alignOneParticleWrapper(particle, reference, referenceWeighting=None, rotati
     @type particle: L{pytom.basic.structures.Particle}
     #@param particleFilename:
     @param reference: reference volume
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param referenceWeighting: Fourier weighting of the reference (sum of wedges for instance)
     @type referenceWeighting: L{pytom.basic.structures.vol}
     @param scoreXMLFilename: name of XML File of score object
@@ -795,7 +797,7 @@ def averageParallel(particleList,averageName, showProgressBar=False, verbose=Fal
     @author: FF
 
     """
-    from pytom_volume import read, complexRealMult
+    from pytom.lib.pytom_volume import read, complexRealMult
     from pytom.basic.fourier import fft,ifft
     from pytom.basic.filter import lowpassFilter
     from pytom.basic.structures import Reference
@@ -805,13 +807,12 @@ def averageParallel(particleList,averageName, showProgressBar=False, verbose=Fal
     splitLists = splitParticleList(particleList, setParticleNodesRatio=setParticleNodesRatio)
     splitFactor = len(splitLists)
     assert splitFactor > 0, "splitFactor == 0, issue with parallelization"
-    print(f'Device = {device}')
     if 'gpu' in device:
         from pytom.bin.average import averageGPU as average
         from pytom.agnostic.structures import Reference
         from pytom.agnostic.io import read, write
 
-        print('Averaging volumes on gpu.')
+        print(f'averaging particles on {device} for {averageName}.')
 
     else:
         gpuIDs = [None,]*splitFactor

--- a/pytom/alignment/GLocalSampling.py
+++ b/pytom/alignment/GLocalSampling.py
@@ -812,7 +812,7 @@ def averageParallel(particleList,averageName, showProgressBar=False, verbose=Fal
         from pytom.agnostic.structures import Reference
         from pytom.agnostic.io import read, write
 
-        print(f'averaging particles on {device} for {averageName}.')
+        print(f'Averaging particles on {device} for {averageName}.')
 
     else:
         gpuIDs = [None,]*splitFactor

--- a/pytom/alignment/GWienerFilterAlignment.py
+++ b/pytom/alignment/GWienerFilterAlignment.py
@@ -7,7 +7,7 @@ Created on Nov 6, 2012
 
 
 from pytom.basic.structures import PyTomClass
-import pytom_mpi
+import pytom.lib.pytom_mpi as pytom_mpi
 from pytom.alignment.FRMAlignment import FRMJob, FRMScore, FRMResult, FRMWorker
 
 class ParticleListPair(PyTomClass):
@@ -76,7 +76,7 @@ class ParticleListPair(PyTomClass):
         return pl
     
     def get_ctf_sqr_vol(self):
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         v = read(self.ctf_sqr)
         return v
 
@@ -301,7 +301,7 @@ class MultiDefocusWorker(FRMWorker):
             from pytom.basic.filter import lowpassFilter
             from math import ceil
             from pytom.basic.fourier import convolute
-            from pytom_volume import vol, power, read
+            from pytom.lib.pytom_volume import vol, power, read
             
             # randomly split the particle list into 2 half sets
             import numpy as np
@@ -402,10 +402,10 @@ class MultiDefocusWorker(FRMWorker):
                 print(self.node_name + ': transform of even set to match the odd set - shift: '+str(pos)+' rotation: '+str(angle))
                 
                 # transform the odd set accordingly
-                from pytom_volume import vol, transformSpline
+                from pytom.lib.pytom_volume import vol, transformSpline
                 from pytom.basic.fourier import ftshift
-                from pytom_volume import reducedToFull
-                from pytom_freqweight import weight
+                from pytom.lib.pytom_volume import reducedToFull
+                from pytom.lib.pytom_freqweight import weight
                 transformed_odd_pre = vol(odd.sizeX(), odd.sizeY(), odd.sizeZ())
                 full_all_odd_wedge = reducedToFull(all_odd_wedge)
                 ftshift(full_all_odd_wedge)
@@ -490,7 +490,7 @@ class MultiDefocusWorker(FRMWorker):
         from pytom.basic.structures import Shift, Rotation
         from pytom.tools.ProgressBar import FixedProgBar
         from pytom.basic.fourier import convolute
-        from pytom_volume import read, power
+        from pytom.lib.pytom_volume import read, power
         
         while True:
             # get the job
@@ -521,7 +521,7 @@ class MultiDefocusWorker(FRMWorker):
             
             if job.bfactor and job.bfactor != 'None':
 #                restore_kernel = create_bfactor_restore_vol(ref.sizeX(), job.sampleInformation.getPixelSize(), job.bfactor)
-                from pytom_volume import vol, read
+                from pytom.lib.pytom_volume import vol, read
                 bfactor_kernel = read(job.bfactor)
                 unit = vol(bfactor_kernel)
                 unit.setAll(1)
@@ -596,8 +596,8 @@ class MultiDefocusWorker(FRMWorker):
     def sum_sub_pl(self, pl, name_prefix):
         """This is a sub-routine for average_sub_pl.
         """
-        from pytom_volume import vol
-        from pytom_volume import transformSpline as transform
+        from pytom.lib.pytom_volume import vol
+        from pytom.lib.pytom_volume import transformSpline as transform
         from pytom.basic.normalise import mean0std1
         
         result = None
@@ -645,7 +645,7 @@ class MultiDefocusWorker(FRMWorker):
     def create_average(self, sum_ctf_conv, sum_ctf_squared, wedge_weight):
         """For the master node, this function is rewritten.
         """
-        from pytom_volume import complexDiv, fullToReduced, limit
+        from pytom.lib.pytom_volume import complexDiv, fullToReduced, limit
         from pytom.basic.fourier import fft, ifft, ftshift
         from pytom.basic.normalise import mean0std1
         

--- a/pytom/alignment/GrowingAverage.py
+++ b/pytom/alignment/GrowingAverage.py
@@ -26,7 +26,7 @@ class GAWorker(PyTomClass):
 
     def run(self):
         
-        import pytom_mpi
+        import pytom.lib.pytom_mpi as pytom_mpi
         from pytom.parallel.messages import StatusMessage,MessageError
         from pytom.basic.exceptions import ParameterError
         from pytom.basic.structures import PyTomClassError
@@ -64,7 +64,7 @@ class GAWorker(PyTomClass):
         """
         
         from pytom.basic.structures import Reference
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         from pytom_fftplan import fftShift
         
         #create reference object - as self.reference and weighting on disk
@@ -222,7 +222,7 @@ class GAManager(PyTomClass):
                 
 def growingAverage(particleClassLists,score,angleObject,mask,destinationDirectory,preprocessing,verbose=False):
     
-    import pytom_mpi
+    import pytom.lib.pytom_mpi as pytom_mpi
     
     
     if not pytom_mpi.isInitialised():

--- a/pytom/alignment/MultiRefAlignment.py
+++ b/pytom/alignment/MultiRefAlignment.py
@@ -13,7 +13,7 @@ def multiRef_EXMXAlign(multiRefJob,doFinalize=True,verbose=False):
     @param doFinalize: Send finalize msgs to workers or not. Default is true  
     @param verbose: Default is false
     """
-    import pytom_mpi
+    import pytom.lib.pytom_mpi as pytom_mpi
     
     if doFinalize:
         pytom_mpi.init()

--- a/pytom/alignment/WienerFilterAlignment.py
+++ b/pytom/alignment/WienerFilterAlignment.py
@@ -5,7 +5,7 @@ Created on Apr 11, 2012
 '''
 
 from pytom.basic.structures import PyTomClass
-import pytom_mpi
+import pytom.lib.pytom_mpi as pytom_mpi
 from pytom.alignment.FRMAlignment import FRMJob, FRMScore, FRMResult, FRMResult, FRMWorker
 
 class ParticleListPair(PyTomClass):
@@ -74,7 +74,7 @@ class ParticleListPair(PyTomClass):
         return pl
     
     def get_ctf_sqr_vol(self):
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         v = read(self.ctf_sqr)
         return v
 
@@ -289,7 +289,7 @@ class MultiDefocusWorker(FRMWorker):
             from pytom.basic.filter import lowpassFilter
             from math import ceil
             from pytom.basic.fourier import convolute
-            from pytom_volume import vol, power, read
+            from pytom.lib.pytom_volume import vol, power, read
             
             new_reference = job.reference
             old_freq = job.freq
@@ -431,7 +431,7 @@ class MultiDefocusWorker(FRMWorker):
         from pytom.basic.structures import Shift, Rotation
         from pytom.tools.ProgressBar import FixedProgBar
         from pytom.basic.fourier import convolute
-        from pytom_volume import read, power
+        from pytom.lib.pytom_volume import read, power
         
         while True:
             # get the job
@@ -456,7 +456,7 @@ class MultiDefocusWorker(FRMWorker):
             
             if job.bfactor and job.bfactor != 'None':
 #                restore_kernel = create_bfactor_restore_vol(ref.sizeX(), job.sampleInformation.getPixelSize(), job.bfactor)
-                from pytom_volume import vol, read
+                from pytom.lib.pytom_volume import vol, read
                 bfactor_kernel = read(job.bfactor)
                 unit = vol(bfactor_kernel)
                 unit.setAll(1)
@@ -524,8 +524,8 @@ class MultiDefocusWorker(FRMWorker):
     def sum_sub_pl(self, pl, name_prefix):
         """This is a sub-routine for average_sub_pl.
         """
-        from pytom_volume import vol
-        from pytom_volume import transformSpline as transform
+        from pytom.lib.pytom_volume import vol
+        from pytom.lib.pytom_volume import transformSpline as transform
         from pytom.basic.normalise import mean0std1
         
         result = None
@@ -572,7 +572,7 @@ class MultiDefocusWorker(FRMWorker):
     def create_average(self, sum_ctf_conv, sum_ctf_squared, wedge_weight):
         """For the master node, this function is rewritten.
         """
-        from pytom_volume import vol, complexDiv, fullToReduced, initSphere, complexRealMult, limit
+        from pytom.lib.pytom_volume import vol, complexDiv, fullToReduced, initSphere, complexRealMult, limit
         from pytom.basic.fourier import fft, ifft, ftshift
         from pytom.basic.normalise import mean0std1
         

--- a/pytom/alignment/alignmentFunctions.py
+++ b/pytom/alignment/alignmentFunctions.py
@@ -791,7 +791,6 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
             # print('Mask is sphere: ', mask.isSphere(), scoreObject._type)
 
             if (not mask.isSphere()) and (scoreObject._type=='FLCFScore'):
-                if 1: print('recalc meanV en stdV')
                 meanV   = meanUnderMask(particle, m, p)
                 stdV    = stdUnderMask(particle, m, p, meanV)
         else:

--- a/pytom/alignment/alignmentFunctions.py
+++ b/pytom/alignment/alignmentFunctions.py
@@ -11,7 +11,7 @@ def invert_WedgeSum( invol, r_max=None, lowlimit=0., lowval=0.):
     invert wedge sum - avoid division by zero and boost of high frequencies
 
     @param invol: input volume
-    @type invol: L{pytom_volume.vol} or L{pytom_volume.vol_comp}
+    @type invol: L{pytom.lib.pytom_volume.vol} or L{pytom.lib.pytom_volume.vol_comp}
     @param r_max: radius
     @type r_max: L{int}
     @param lowlimit: lower limit - all values below this value that lie in the specified radius will be replaced \
@@ -152,8 +152,8 @@ def applySymmetryToVolume(volume,symmetryObject,wedgeInfo):
     applySymmetryToVolume
     @deprecated: use L{pytom.basic.structures.Symmetry.apply} instead!
     """
-    from pytom_volume import read,rotate,shift,vol,initSphere,complexDiv
-    from pytom_freqweight import weight
+    from pytom.lib.pytom_volume import read,rotate,shift,vol,initSphere,complexDiv
+    from pytom.lib.pytom_freqweight import weight
     from pytom.basic.fourier import fft,ifft,ftshift
     from pytom.basic.filter import filter
     from pytom.alignment.structures import ExpectationResult
@@ -208,11 +208,11 @@ def _disrtibuteAverageMPI(particleList,averageName,showProgressBar = False,verbo
     @author: Thomas Hrabe
     """
     
-    import pytom_mpi
+    import pytom.lib.pytom_mpi as pytom_mpi
     from pytom.alignment.structures import ExpectationJob
     from pytom.parallel.parallelWorker import ParallelWorker
     from pytom.parallel.alignmentMessages import ExpectationJobMsg
-    from pytom_volume import read,complexDiv,complexRealMult
+    from pytom.lib.pytom_volume import read,complexDiv,complexRealMult
     from pytom.basic.fourier import fft,ifft
     from pytom.basic.filter import lowpassFilter
     from pytom.basic.structures import Reference
@@ -303,7 +303,7 @@ def distributeAverage(particleList,averageName,showProgressBar = False,verbose=F
     @author: Thomas Hrabe
     """
 
-    import pytom_mpi
+    import pytom.lib.pytom_mpi as pytom_mpi
     
     mpiInitialized = pytom_mpi.isInitialised()
     mpiAvailable = False
@@ -345,9 +345,9 @@ def average( particleList, averageName, showProgressBar=False, verbose=False,
     @author: Thomas Hrabe
     @change: limit for wedgeSum set to 1% or particles to avoid division by small numbers - FF
     """
-    from pytom_volume import read,vol,reducedToFull,limit, complexRealMult
+    from pytom.lib.pytom_volume import read,vol,reducedToFull,limit, complexRealMult
     from pytom.basic.filter import lowpassFilter, rotateWeighting
-    from pytom_volume import transformSpline as transform
+    from pytom.lib.pytom_volume import transformSpline as transform
     from pytom.basic.fourier import convolute
     from pytom.basic.structures import Reference
     from pytom.basic.normalise import mean0std1
@@ -491,8 +491,8 @@ def average2(particleList, weighting=False, norm=False, determine_resolution=Fal
     2nd version of average function. Will not write the averages to the disk. Also support internal \
     resolution determination.
     """
-    from pytom_volume import read, vol, complexDiv, complexRealMult
-    from pytom_volume import transformSpline as transform
+    from pytom.lib.pytom_volume import read, vol, complexDiv, complexRealMult
+    from pytom.lib.pytom_volume import transformSpline as transform
     from pytom.basic.fourier import fft, ifft, convolute
     from pytom.basic.normalise import mean0std1
     from pytom.tools.ProgressBar import FixedProgBar
@@ -667,11 +667,11 @@ def _rotateWedgeReference(reference,rotation,wedgeInfo,mask,rotationCenter):
     @param wedgeInfo: Wedge info object
     @type wedgeInfo: L{pytom.basic.structures.Wedge}
     @param mask: The mask object (a volume) or None
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @return:
     @change: support mask == None, FF
     """
-    from pytom_volume import vol, transform as transform #developers: your can also import transformSpline for more accurate rotation!
+    from pytom.lib.pytom_volume import vol, transform as transform #developers: your can also import transformSpline for more accurate rotation!
     
     rotatedVolume = vol(reference.sizeX(),reference.sizeY(),reference.sizeZ())
     transform(reference,rotatedVolume,rotation[0],rotation[1],rotation[2],rotationCenter[0],rotationCenter[1],rotationCenter[2],0,0,0,0,0,0)
@@ -688,9 +688,9 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
     """
     bestAlignment: Determines best alignment of particle relative to the reference
     @param particle: A particle
-    @type particle: L{pytom_volume.vol}
+    @type particle: L{pytom.lib.pytom_volume.vol}
     @param reference: A reference
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param referenceWeighting: Fourier weighting of the reference (sum of wedges for instance)
     @type referenceWeighting: L{pytom.basic.structures.vol}
     @param wedgeInfo: What does the wedge look alike?
@@ -713,7 +713,7 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
     """
     from pytom.basic.correlation import subPixelPeak, subPixelPeakParabolic
     from pytom.alignment.structures import Peak
-    from pytom_volume import peak, vol, vol_comp
+    from pytom.lib.pytom_volume import peak, vol, vol_comp
     from pytom.basic.filter import filter,rotateWeighting
     from pytom.basic.structures import Rotation, Shift, Particle, Mask
     from pytom.angles.angle import AngleObject
@@ -772,7 +772,7 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
     particleCopy.copyVolume(particle)
 
     if mask:
-        from pytom_volume import sum
+        from pytom.lib.pytom_volume import sum
         from pytom.basic.correlation import meanUnderMask, stdUnderMask
         p = sum(m)
         meanV = meanUnderMask(particle, m, p)
@@ -802,7 +802,7 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
         
         #weight particle
         if not referenceWeighting.__class__ == str:
-            from pytom_freqweight import weight
+            from pytom.lib.pytom_freqweight import weight
             weightingRotated = rotateWeighting(weighting=referenceWeighting, z1=currentRotation[0],
                                                z2=currentRotation[1], x=currentRotation[2], isReducedComplex=True,
                                                returnReducedComplex=True, binarize=False)
@@ -882,9 +882,9 @@ def bestAlignmentGPU(particle, rotations, plan, preprocessing=None, wedgeInfo=No
     """
     bestAlignment: Determines best alignment of particle relative to the reference
     @param particle: A particle
-    @type particle: L{pytom_volume.vol}
+    @type particle: L{pytom.lib.pytom_volume.vol}
     @param reference: A reference
-    @type reference: L{pytom_volume.vol}
+    @type reference: L{pytom.lib.pytom_volume.vol}
     @param referenceWeighting: Fourier weighting of the reference (sum of wedges for instance)
     @type referenceWeighting: L{pytom.basic.structures.vol}
     @param wedgeInfo: What does the wedge look alike?
@@ -986,7 +986,7 @@ def compareTwoVolumes(particle,reference,referenceWeighting,wedgeInfo,rotations,
     @author: Thomas Hrabe
     """
 
-    from pytom_volume import vol,transformSpline
+    from pytom.lib.pytom_volume import vol,transformSpline
     from pytom.basic.filter import filter,rotateWeighting
     from pytom.angles.angleList import OneAngleList
     
@@ -1030,7 +1030,7 @@ def compareTwoVolumes(particle,reference,referenceWeighting,wedgeInfo,rotations,
     simulatedVol = preprocessing.apply(simulatedVol,True)
 
     if not referenceWeighting.__class__ == str:
-        from pytom_freqweight import weight
+        from pytom.lib.pytom_freqweight import weight
         
         weightingRotated = rotateWeighting(weighting=referenceWeighting, z1=currentRotation[0], z2=currentRotation[1],
                                            x=currentRotation[2], isReducedComplex=None, returnReducedComplex=True,

--- a/pytom/alignment/localOptimization.py
+++ b/pytom/alignment/localOptimization.py
@@ -14,13 +14,13 @@ class Alignment:
         alignment of a particle against a reference
 
         @param vol1: (constant) volume
-        @type vol1: L{pytom_volume.vol}
+        @type vol1: L{pytom.lib.pytom_volume.vol}
         @param vol2: volume that is matched to reference
-        @type vol2: L{pytom_volume.vol}
+        @type vol2: L{pytom.lib.pytom_volume.vol}
         @param score: score for alignment - e.g., pytom.basic.correlation.nxcc
         @type score: L{pytom.basic.correlation}
         @param mask: mask correlation is constrained on
-        @type mask: L{pytom_volume.vol}
+        @type mask: L{pytom.lib.pytom_volume.vol}
         @param iniRot: initial rotation of vol2
         @type iniRot: L{pytom.basic.Rotation}
         @param iniTrans: initial translation of vol2
@@ -34,7 +34,7 @@ class Alignment:
         """
         from pytom.basic.normalise import normaliseUnderMask, mean0std1
         from pytom.tools.macros import volumesSameSize
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from pytom.basic.structures import Rotation, Shift
         assert isinstance(interpolation, str), "interpolation must be of type str"
 
@@ -150,7 +150,7 @@ class Alignment:
         set search volume (vol1 internally)
 
         @param vol1: search volume
-        @type vol1: L{pytom_volume.vol}
+        @type vol1: L{pytom.lib.pytom_volume.vol}
 
         """
         from pytom.basic.normalise import normaliseUnderMask, mean0std1
@@ -171,7 +171,7 @@ class Alignment:
         @type rot_trans: L{list}
         @author: FF
         """
-        from pytom_volume import transformSpline, transform
+        from pytom.lib.pytom_volume import transformSpline, transform
         if self.interpolation.lower() == 'spline':
             transformSpline(self.vol2, self.rotvol2, rot_trans[0], rot_trans[1], rot_trans[2],
                             self.centX,self.centY,self.centZ,0,0,0,
@@ -195,7 +195,7 @@ class Alignment:
         @rtype: L{float}
         @author: FF
         """
-        from pytom_volume import transformSpline
+        from pytom.lib.pytom_volume import transformSpline
 
         #transform vol2
         transformSpline( self.vol2, self.rotvol2, rot[0], rot[1], rot[2],
@@ -266,7 +266,7 @@ def alignVolumesAndFilterByFSC(vol1, vol2, mask=None, nband=None, iniRot=None, i
     @param vol1: volume 1
     @param vol2: volume 2
     @mask: mask volume
-    @type mask: L{pytom_volume.vol}
+    @type mask: L{pytom.lib.pytom_volume.vol}
     @param nband: Number of bands
     @type nband: L{int}
     @param iniRot: initial guess for rotation
@@ -282,7 +282,7 @@ def alignVolumesAndFilterByFSC(vol1, vol2, mask=None, nband=None, iniRot=None, i
         note: filvol2 is NOT rotated and translated!
     @author: FF
     """
-    from pytom_volume import transformSpline, vol
+    from pytom.lib.pytom_volume import transformSpline, vol
     from pytom.basic.correlation import FSC
     from pytom.basic.filter import filter_volume_by_profile
     from pytom.alignment.localOptimization import Alignment
@@ -381,33 +381,3 @@ def design_fsc_filter(fsc, fildim=None, fsc_criterion=0.143):
         else:
             fil[ii] = fsc_fil[ii]
     return fil
-
-
-def alignVolumes(particle, reference, referenceWeighting, wedgeInfo, iniRot, iniTrans,
-                 scoreObject=0, mask=None, preprocessing=None, progressBar=False, binning=1,
-                 bestPeak=None, verbose=False):
-    """
-    Analog to bestAlignment function for local optimization
-    @param particle: A particle
-    @type particle: L{pytom_volume.vol}
-    @param reference: A reference
-    @type reference: L{pytom_volume.vol}
-    @param referenceWeighting: Fourier weighting of the reference (sum of wedges for instance)
-    @type referenceWeighting: L{pytom.basic.structures.vol}
-    @param wedgeInfo: What does the wedge look alike?
-    @type wedgeInfo: L{pytom.basic.structures.Wedge}
-    @param iniRot: initial guess for rotation
-    @param iniTrans: initial guess for translation
-    @param scoreObject:
-    @type scoreObject: L{pytom.score.score.Score}
-    @param mask: real-space mask for correlation function
-    @type mask: L{pytom.basic.structures.Particle}
-    @param preprocessing: Class storing preprocessing of particle and reference such as bandpass
-    @type preprocessing: L{pytom.alignment.preprocessing.Preprocessing}
-    @param progressBar: Display progress bar of alignment. False by default.
-    @param binning: Is binning applied (currently not properly functioning)
-    @param bestPeak: Initialise best peak with old values.
-    @param verbose: Print out infos. Writes CC volume to disk!!! Default is False
-    @return: Returns the best rotation for particle and the corresponding scoring result.
-
-    """

--- a/pytom/alignment/preprocessing.py
+++ b/pytom/alignment/preprocessing.py
@@ -79,16 +79,16 @@ class Preprocessing(PyTomClass):
         """
         apply: Performs preprocessing of volume and reference
         @param volume: volume to be pre-processed
-        @type volume: L{pytom_volume.vol}
+        @type volume: L{pytom.lib.pytom_volume.vol}
         @param bypassFlag: Set if only bandpassFilter needed. False otherwise and all routines will be processed.
         @param downscale: not used anymore
         @param particle: particle Volume to be subtracted from input volume
-        @type particle: L{pytom_volume.vol}
+        @type particle: L{pytom.lib.pytom_volume.vol}
         @return: Returns modified volume
         @author: Thomas Hrabe  
         """
         
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         
         if self._bandpassOn:
 
@@ -109,7 +109,7 @@ class Preprocessing(PyTomClass):
 
         if self._prerotateOn and (not bypassFlag):
             
-            from pytom_volume import rotate
+            from pytom.lib.pytom_volume import rotate
         
             rot = vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
             rotation = self.prerotate
@@ -118,8 +118,8 @@ class Preprocessing(PyTomClass):
 
         if self._weightingOn and (not bypassFlag):
             
-            from pytom_volume import read
-            from pytom_freqweight import weight
+            from pytom.lib.pytom_volume import read
+            from pytom.lib.pytom_freqweight import weight
             from pytom.basic.fourier import fft, ifft
             
             wedgeSum = read(self._weightingFile)

--- a/pytom/alignment/structures.py
+++ b/pytom/alignment/structures.py
@@ -641,7 +641,7 @@ class AlignmentList(PyTomClass):
         @type filename: L{str}
         @todo: add unit test
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         l = self.len()
         motif = vol(20,l,1)
         motif.setAll(0)

--- a/pytom/angles/angle.py
+++ b/pytom/angles/angle.py
@@ -344,7 +344,7 @@ class AngleObject(PyTomClass):
         @param filename: Name of file to save to 
         @param inputIsRadians: 
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         
         no = self.numberRotations()
          
@@ -376,7 +376,7 @@ class AngleObject(PyTomClass):
         """
         from pytom.tools.toImage import volumeToPNG
         from pytom.tools.files import dump2TextFile
-        from pytom_volume import vol,rotateSpline
+        from pytom.lib.pytom_volume import vol,rotateSpline
         from pytom.tools.files import getPytomPath,readStringFile
         from pytom.frontend.htmlDefines import headResponse200,copyright
     
@@ -429,10 +429,10 @@ class AngleObject(PyTomClass):
         """
         rotationDistanceMatrix: Generate a matrix of rotation distances. The 
         distance is determined by L{pytom.angles.quaternions.Quaternion.distance}.
-        @return: L{pytom_volume.vol} of rotation distances
+        @return: L{pytom.lib.pytom_volume.vol} of rotation distances
         @author: Thomas Hrabe
         """
-        from pytom_volume import vol
+        from pytom.lib.pytom_volume import vol
         from pytom.tools.maths import rotation_distance
         numberOfRotations = len(self)
 

--- a/pytom/basic/correlation.py
+++ b/pytom/basic/correlation.py
@@ -312,10 +312,7 @@ def FLCF(volume, template, mask=None, stdV=None, wedge=1):
     @author: Yuxiang Chen
     '''
     from pytom.lib.pytom_volume import vol, pasteCenter, conjugate, sum
-    from pytom.basic.files import read
     from pytom.basic.fourier import fft, ifft, iftshift
-    from pytom.basic.structures import Mask
-    from pytom.basic.files import write_em
 
     if volume.__class__ != vol and template.__class__ != vol:
         raise RuntimeError('Wrong input type!')
@@ -386,7 +383,6 @@ def bandCC(volume,reference,band,verbose = False):
     """
     import pytom.lib.pytom_volume as pytom_volume
     from pytom.basic.filter import bandpassFilter
-    from pytom.basic.correlation import xcf
     from math import sqrt
     
     if verbose:

--- a/pytom/basic/maths.py
+++ b/pytom/basic/maths.py
@@ -2,23 +2,23 @@ def power(volume,exponent,inplace=False):
     """
     power: Pixelwise power 
     @param volume: The volume
-    @type volume: L{pytom_volume.vol}
+    @type volume: L{pytom.lib.pytom_volume.vol}
     @param exponent: The exponent
     @type exponent: L{float}
     @param inplace: Perform power inplace? Default is False   
     @type inplace: L{bool}
     @return: volume
-    @rtype: L{pytom_volume.vol}
+    @rtype: L{pytom.lib.pytom_volume.vol}
     """
 
     if inplace:
-        from pytom_volume import power
+        from pytom.lib.pytom_volume import power
         
         power(volume,exponent)
 
     else:
         #return new volume object
-        from pytom_volume import vol,power
+        from pytom.lib.pytom_volume import vol,power
         
         volume2 = vol(volume.sizeX(),volume.sizeY(),volume.sizeZ())
         volume2.copyVolume(volume)
@@ -32,14 +32,14 @@ def determineRotationCenter(particle, binning):
     """
     determineRotationCenter:
     @param particle: The particle 
-    @type particle: Either L{pytom_volume.vol} or string specifying the particle file name 
+    @type particle: Either L{pytom.lib.pytom_volume.vol} or string specifying the particle file name
     @param binning: Binning factor
     @return: [centerX,centerY,centerZ]  
 
     @author: Thomas Hrabe
     """
     if particle.__class__ == str:
-        from pytom_volume import read
+        from pytom.lib.pytom_volume import read
         particle = read(particle)
     
     centerX = particle.sizeX() / 2.0 * (1.0/float(binning)) 

--- a/pytom/bin/average.py
+++ b/pytom/bin/average.py
@@ -43,9 +43,9 @@ def average(particleList, averageName, showProgressBar=False, verbose=False,
     @author: Thomas Hrabe
     @change: limit for wedgeSum set to 1% or particles to avoid division by small numbers - FF
     """
-    from pytom_volume import read, vol, reducedToFull
+    from pytom.lib.pytom_volume import read, vol, reducedToFull
     from pytom.basic.filter import lowpassFilter, rotateWeighting
-    from pytom_volume import transformSpline as transform
+    from pytom.lib.pytom_volume import transformSpline as transform
     from pytom.basic.fourier import convolute
     from pytom.basic.structures import Reference
     from pytom.basic.normalise import mean0std1
@@ -357,7 +357,6 @@ def averageGPU(particleList, averageName, showProgressBar=False, verbose=False,
         cstream.synchronize()
         n+=1
 
-    print('averaged particles')
     ###apply spectral weighting to sum
 
     root, ext = os.path.splitext(averageName)
@@ -395,7 +394,7 @@ def invert_WedgeSum( invol, r_max=None, lowlimit=0., lowval=0.):
     invert wedge sum - avoid division by zero and boost of high frequencies
 
     @param invol: input volume
-    @type invol: L{pytom_volume.vol} or L{pytom_volume.vol_comp}
+    @type invol: L{pytom.lib.pytom_volume.vol} or L{pytom.lib.pytom_volume.vol_comp}
     @param r_max: radius
     @type r_max: L{int}
     @param lowlimit: lower limit - all values below this value that lie in the specified radius will be replaced \
@@ -476,7 +475,7 @@ def averageParallel(particleList,averageName, showProgressBar=False, verbose=Fal
     @author: FF
 
     """
-    from pytom_volume import read, complexRealMult
+    from pytom.lib.pytom_volume import read, complexRealMult
     from pytom.basic.fourier import fft,ifft
     from pytom.basic.filter import lowpassFilter
     from pytom.basic.structures import Reference
@@ -586,12 +585,12 @@ def averageParallelGPU(particleList, averageName, showProgressBar=False, verbose
     @author: FF
 
     """
-    from pytom_volume import read, complexRealMult
+    from pytom.lib.pytom_volume import read, complexRealMult
     from pytom.basic.fourier import fft, ifft
     from pytom.basic.filter import lowpassFilter
     from pytom.basic.structures import Reference
     from pytom.agnostic.tools import invert_WedgeSum
-    from pytom_numpy import vol2npy
+    from pytom.lib.pytom_numpy import vol2npy
     from pytom.agnostic.io import write, read
     import os
 

--- a/tests/E2ETests/helper_functions.py
+++ b/tests/E2ETests/helper_functions.py
@@ -16,7 +16,7 @@ def create_RandomParticleList( reffile, pl_filename='pl.xml', pdir='./testpartic
     
     """
     from pytom.basic.structures import Particle, ParticleList, Rotation, Shift, Wedge
-    from pytom_volume import read
+    from pytom.lib.pytom_volume import read
     from pytom.basic.transformations import general_transform_crop
     from pytom.basic.functions import initSphere
     from pytom.simulation.support import add_white_noise as addNoise

--- a/tests/E2ETests/test_GLocalTest.py
+++ b/tests/E2ETests/test_GLocalTest.py
@@ -9,7 +9,7 @@ class pytom_GLocalTest(unittest.TestCase):
     def setUp(self):
         from helper_functions import create_RandomParticleList, installdir
         from pytom.agnostic.io import read_size
-        from pytom_volume import vol, initSphere
+        from pytom.lib.pytom_volume import vol, initSphere
 
         self.installdir = installdir
         self.reffile = f'../testData/ribo.em'
@@ -28,20 +28,15 @@ class pytom_GLocalTest(unittest.TestCase):
         initSphere(maskvol, 30,5, 0, int(dims[0]/2), int(dims[1]/2), int(dims[2]/2))
         maskvol.write(self.settings["mask"])
         self.settings["destination"] = './'
-        #self.settings["score"] = 'nxcf'
         self.settings["score"] = 'flcf'
         self.settings["pixelsize"] = 2.
         self.settings["diameter"] = 250.
         self.settings["job"] = './myGLocal.xml'
 
-    #def tearDown(self):
-        #self.cleanUp()
-
     def cleanUp(self):
         """
         check that files are written and remove them
         """
-        from helper_functions import cleanUp_RandomParticleList
         from os import system
 
         for ii in range(0, self.settings["niteration"]):
@@ -91,7 +86,6 @@ class pytom_GLocalTest(unittest.TestCase):
         fname='average-FinalFiltered_*.em'
         system('rm '+fname)
         system(f'rm {self.pl_filename}')
-        #cleanUp_RandomParticleList( pl_filename=self.pl_filename, pdir=self.pdir)
 
     def remove_file(self, filename):
         """
@@ -107,14 +101,13 @@ class pytom_GLocalTest(unittest.TestCase):
         if filecheck:
             remove(filename)
 
-
     def xtest_Score(self):
         """
         test implementation of different scores
         """
         import os
 
-        cmd = f'mpirun -np 2 {self.installdir}/bin/pytom {self.installdir}/bin/GLocalJob.py'
+        cmd = f'mpirun -np 1 {self.installdir}/bin/pytom {self.installdir}/bin/GLocalJob.py'
         cmd = cmd + ' -p ' + self.pl_filename
         cmd = cmd + ' -m ' + str(self.settings["mask"])
         cmd = cmd + ' -b ' + str(self.settings["binning"])
@@ -124,7 +117,6 @@ class pytom_GLocalTest(unittest.TestCase):
         cmd = cmd + ' --pixelSize ' + str(self.settings["pixelsize"])
         cmd = cmd + ' --particleDiameter ' + str(self.settings["diameter"])
         cmd = cmd + ' -j ' + str(self.settings["job"])
-        #cmd = cmd + ' -r ' + str(self.settings["reference"])
         print(cmd)
         os.system(cmd)
         self.cleanUp()
@@ -137,7 +129,9 @@ class pytom_GLocalTest(unittest.TestCase):
 
         self.settings["score"] = 'nxcf'
 
-        cmd = f'mpirun -np 2 {self.installdir}/bin/pytom {self.installdir}/bin/GLocalJob.py -g 0'
+        # had to change number of mpi procs to 1 to comply with running on single gpu
+        # BUT: All the docs say that the number of mpi processes should be ( number_of_gpus + 1 )
+        cmd = f'mpirun -np 1 {self.installdir}/bin/pytom {self.installdir}/bin/GLocalJob.py -g 0'
         cmd = cmd + ' -p ' + self.pl_filename
         cmd = cmd + ' -m ' + str(self.settings["mask"])
         cmd = cmd + ' -b ' + str(self.settings["binning"])
@@ -147,12 +141,10 @@ class pytom_GLocalTest(unittest.TestCase):
         cmd = cmd + ' --pixelSize ' + str(self.settings["pixelsize"])
         cmd = cmd + ' --particleDiameter ' + str(self.settings["diameter"])
         cmd = cmd + ' -j ' + str(self.settings["job"])
-        #cmd = cmd + ' -r ' + str(self.settings["reference"])
         print(cmd)
         os.system(cmd)
-        # self.cleanUp()
 
-        cmd = f'mpirun -np 2 {self.installdir}/bin/pytom {self.installdir}/bin/GLocalJob.py '
+        cmd = f'mpirun -np 1 {self.installdir}/bin/pytom {self.installdir}/bin/GLocalJob.py '
         cmd = cmd + ' -p ' + self.pl_filename
         cmd = cmd + ' -m ' + str(self.settings["mask"])
         cmd = cmd + ' -b ' + str(self.settings["binning"])
@@ -162,7 +154,6 @@ class pytom_GLocalTest(unittest.TestCase):
         cmd = cmd + ' --pixelSize ' + str(self.settings["pixelsize"])
         cmd = cmd + ' --particleDiameter ' + str(self.settings["diameter"])
         cmd = cmd + ' -j ' + str(self.settings["job"])
-        # cmd = cmd + ' -r ' + str(self.settings["reference"])
         print(cmd)
         os.system(cmd)
         self.cleanUp()


### PR DESCRIPTION
The test now compares two different score function both on cpu and gpu. Alongside this, I had to update the import of pytom_volume to accomodate pytom.lib import. Overview of changes:

- Added test for flcf scoring next to nxcf scoring
- Both cpu and gpu tests are present
- Had to make a lot of changes in the import of `pytom_volume`/`pytom_numpy`/`pytom_mpi`
- Removed some printing statements that were cluttering up the terminal while running (where possible I added them under verbose)

Some issues also came to my attention while running:

- More of the e2e tests need updates, and when they are all working we should agree to run them locally before committing. Which might require running with GPU support, otherwise a lot of functionality is not tested. I will make an issue about updating them.
- We could reduce the size of the test particles (downsampling them 4 times for example), because the resolution after averaging is still within that margin, to speed up the test. That might allow including them in the unittesting (instead of e2e-tests).
- I probably need to go through more of the pytom_volume imports because quite some things escaped the tests. I already made an issue about this.
- The spherical harmonics C++ library that support frm-alignment is not present in conda. Updating the autofocus e2e test would cover testing this because it uses frm as the alingment backend. The first point covers this.
- openmpi parallelization is not working as expected in the glocal unittest. With a single gpu the number of mpi procs should be 2 (always one more than the number of gpus), but when setting this it will crash because it tries to everything 2 times. I would expect one slave process to do the work on the gpu, while the master controls it. Will make an issue about this as well.