### PR TITLE
fix for development mode install

### DIFF
--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -4081,7 +4081,7 @@ class Shift(PyTomClass):
         @return: rotated shift (note: shift itself remains unaltered)
         @rtype: L{pytom.agnostic.structures.Shift}
         """
-        assert isinstance(object=rot, class_or_type_or_tuple=Rotation), "rot must be of type Rotation"
+        assert isinstance(rot, Rotation), "rot must be of type Rotation"
         m = rot.toMatrix(fourByfour=True) * self.toMatrix()
         return Shift(x=m.getColumn(3)[0], y=m.getColumn(3)[1], z=m.getColumn(3)[2])
 

--- a/pytom/alignment/GLocalSampling.py
+++ b/pytom/alignment/GLocalSampling.py
@@ -43,7 +43,7 @@ def mainAlignmentLoop(alignmentJob, verbose=False):
 
         filetype = 'em'
 
-    assert isinstance(object=alignmentJob, class_or_type_or_tuple=GLocalSamplingJob), \
+    assert isinstance(alignmentJob, GLocalSamplingJob), \
         "mainAlignmentLoop: alignmentJob must be of type GLocalSamplingJob"
     mpi.begin()
     print("particleList    = "+str(alignmentJob.particleList.getFileName()))
@@ -578,7 +578,8 @@ def alignParticleListGPU(pl, reference, referenceWeightingFile, rotationsFilenam
     @author: FF
     """
     from pytom.angles.angle import AngleObject
-    from pytom.agnostic.structures import Mask, ParticleList
+    from pytom.basic.structures import ParticleList
+    from pytom.agnostic.structures import Mask
     from pytom.agnostic.transform import resize
     from pytom.alignment.alignmentFunctions import bestAlignmentGPU
     from pytom.gpu.gpuStructures import GLocalAlignmentPlan
@@ -719,7 +720,7 @@ def alignOneParticle( particle, reference, referenceWeighting, rotations,
     @author: FF
     """
     from pytom.basic.structures import Particle, Reference, Mask, Wedge, WedgeInfo
-    from pytom.angles.angleList import AngleList
+    from pytom.angles.angle import AngleObject
     from pytom.alignment.alignmentFunctions import bestAlignment
     from pytom.basic.score import Score
     from pytom.alignment.preprocessing import Preprocessing
@@ -746,11 +747,11 @@ def alignOneParticle( particle, reference, referenceWeighting, rotations,
     refVol = preprocessing.apply(volume=refVol, bypassFlag=True)
 
     wedge = particle.getWedge()
-    assert type(scoreObject) == Score, "alignOneParticle: score not of type Score"
+    assert isinstance(scoreObject, Score), "alignOneParticle: score not of type Score"
     if mask:
         assert type(mask) == Mask, "alignOneParticle: mask not of type Mask"
 
-    assert type(rotations) == AngleList, "alignOneParticle: rotations not of type AngleList"
+    assert isinstance(rotations, AngleObject), "alignOneParticle: rotations not of type AngleList"
 
     oldRot = particle.getRotation()
     rotations.setStartRotation(oldRot)
@@ -928,7 +929,7 @@ def writeParticleListToUniqueFile(pl, dirName=None):
     """
     from uuid import uuid4
     from pytom.basic.structures import ParticleList
-    assert isinstance(object=pl, class_or_type_or_tuple=ParticleList), \
+    assert isinstance(pl, ParticleList), \
         "writeParticleListToUniqueFile: pl must be of type ParticleList"
     fname = str(uuid4())
     if dirName:

--- a/pytom/alignment/alignmentStructures.py
+++ b/pytom/alignment/alignmentStructures.py
@@ -292,7 +292,7 @@ class GLocalSamplingJob(PyTomClass):
             "GLocalSamplingJob: ref must be Reference or None"
         if score is None:
             score = FLCFScore()
-        assert type(score) == Score or type(score) == FLCFScore, "GLocalSamplingJob: score is of type Score"
+        assert isinstance(score, Score), "GLocalSamplingJob: score is of type Score"
         assert (type(mask) == Mask) or (type(mask) == type(None)), \
             "GLocalSamplingJob: mask is of type Mask"
         if preprocessing is None:
@@ -309,10 +309,8 @@ class GLocalSamplingJob(PyTomClass):
                                                    preprocessing=preprocessing, fsc_criterion=fsc_criterion,
                                                    symmetries=symmetries)
         if rotations is None:
-            from pytom.angles.localSampling import LocalSampling
             rotations = LocalSampling(shells=3, increment=3., z1Start=0., z2Start=0., xStart=0.)
-        assert type(rotations) == LocalSampling or type(
-            rotations) == AngleObject, "GLocalSamplingJob: rotations is LocalSampling"
+        assert isinstance(rotations, AngleObject), "GLocalSamplingJob: rotations is LocalSampling"
         assert type(binning) == int, "GLocalSamplingJob: binning is an int"
         assert type(adaptive_res) == float, "GLocalSamplingJob: adaptive_res is of type float"
         self.samplingParameters = SamplingParameters(rotations=rotations,

--- a/pytom/alignment/localOptimization.py
+++ b/pytom/alignment/localOptimization.py
@@ -288,8 +288,8 @@ def alignVolumesAndFilterByFSC(vol1, vol2, mask=None, nband=None, iniRot=None, i
     from pytom.alignment.localOptimization import Alignment
     from pytom.basic.correlation import nxcc
 
-    assert isinstance(object=vol1, class_or_type_or_tuple=vol), "alignVolumesAndFilterByFSC: vol1 must be of type vol"
-    assert isinstance(object=vol2, class_or_type_or_tuple=vol), "alignVolumesAndFilterByFSC: vol2 must be of type vol"
+    assert isinstance(vol1, vol), "alignVolumesAndFilterByFSC: vol1 must be of type vol"
+    assert isinstance(vol2, vol), "alignVolumesAndFilterByFSC: vol2 must be of type vol"
     # filter volumes prior to alignment according to SNR
     fsc = FSC(volume1=vol1, volume2=vol2, numberBands=nband)
     fil = design_fsc_filter(fsc=fsc, fildim=int(vol2.sizeX()//2))

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -4088,7 +4088,7 @@ class Shift(PyTomClass):
         @return: rotated shift (note: shift itself remains unaltered)
         @rtype: L{pytom.basic.structures.Shift}
         """
-        assert isinstance(object=rot, class_or_type_or_tuple=Rotation), "rot must be of type Rotation"
+        assert isinstance(rot, Rotation), "rot must be of type Rotation"
         m = rot.toMatrix(fourByfour=True) * self.toMatrix()
         return Shift(x=m.getColumn(3)[0], y=m.getColumn(3)[1], z=m.getColumn(3)[2])
     

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,18 @@ class PyTomDeveloper(develop):
         compile_pytom(pathlib.Path(self.prefix))
         develop.run(self)
 
+        """Hacky solution, but we cannot rely on the script linking of pip in develop-mode. Pip will put scripts in the 
+        miniconda bin that have a different shebang than the original ones. However, we need the pytom shebang for GPU 
+        scripts to execute. Only then is the GPU environment variable properly set. Updating gpu code to the cupy 
+        advised agnostic setup (as put in PyTomPrivate issue #117) should also solve this."""
+        miniconda_bin = pathlib.Path(self.prefix)
+        scripts = find_executables()
+        for script in scripts:
+            script_path = pathlib.Path(script)
+            symlink_path = miniconda_bin.joinpath('bin', script_path.name)
+            symlink_path.unlink()
+            symlink_path.symlink_to(script_path.absolute())
+
 
 setup(
     name='pytom',

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,39 @@
 from setuptools import setup, find_namespace_packages
 from setuptools.command.install import install
+from setuptools.command.develop import develop
 
 import subprocess
 import sys
-import os
+import pathlib
 from pytom import __version__
 
 
-def find_angle_lists(folder):
-    return [e for e in os.listdir(folder) if e.endswith('.em') and e.startswith('angles_')]
-
-
 def find_executables():
-    folder = 'pytom/bin'
-    a = [f'{folder}/{e}' for e in os.listdir(folder) if os.path.isfile(f'{folder}/{e}') and not '__' in e] + \
-        ['pytom/bin/pytom', 'pytom/bin/ipytom', 'pytom/bin/pytomGUI']
-    return a
+    bin_folder = pathlib.Path('pytom/bin')
+    executables = [str(path) for path in bin_folder.iterdir() if path.is_file() and '__' not in path.name]
+    return executables + [str(bin_folder.joinpath(f)) for f in ['pytom', 'ipytom', 'pytomGUI']]
 
 
-class CustomInstall(install):
+def compile_pytom(miniconda_dir):
+    install_command = f'{sys.executable} compile.py --target all'
+    if miniconda_dir.exists():
+        install_command += f' --minicondaEnvDir {miniconda_dir}'
+    process = subprocess.Popen(install_command, shell=True, cwd="pytom/pytomc")
+    process.wait()
+
+
+class PyTomInstaller(install):
     def run(self):
-        condadir = self.prefix
-        version = f'{sys.version_info[0]}.{sys.version_info[1]}'
-        commandInstall = f'{sys.executable} compile.py --target all'
-        if os.path.exists(condadir): commandInstall += f' --minicondaEnvDir {condadir}' 
-        process = subprocess.Popen(commandInstall, shell=True, cwd="pytom/pytomc")
-        process.wait()
+        compile_pytom(pathlib.Path(self.prefix))
         install.run(self)
+
+
+class PyTomDeveloper(develop):
+    def run(self):
+        compile_pytom(pathlib.Path(self.prefix))
+        develop.run(self)
+
+
 setup(
     name='pytom',
     version=__version__,
@@ -37,16 +44,17 @@ setup(
         'pytom.simulation.detectors': ['*.csv'],
         'pytom.simulation.membrane_models': ['*.pdb']
     },
-    data_files=[("pytom_data", ["./LICENSE.txt"])], # This is a relative dir to sys.prefix
+    data_files=[("pytom_data", ["./LICENSE.txt"])],  # This is a relative dir to sys.prefix
     include_package_data=True,
     author='`FridoF',
-    author_email='gijsschot@gmail.com',
-    url='https://github.com/FridoF/PyTomPrivate.git',
-    install_requires=['lxml', 'PyFFTW', 'scipy', 'boost', 'numpy'],
+    author_email='strubi.pytom@uu.nl',
+    url='https://github.com/SBC-Utrecht/PyTom.git',
+    install_requires=['lxml', 'scipy', 'boost', 'numpy'],
     extras_require={
         'gpu': ['cupy'],
         'gui': ['PyQt5', 'pyqtgraph', 'mrcfile'],
         'all': ['cupy', 'PyQt5', 'pyqtgraph', 'mrcfile']},
-    cmdclass={'install': CustomInstall},
+    cmdclass={'install': PyTomInstaller,
+              'develop': PyTomDeveloper},
     scripts=find_executables())
 


### PR DESCRIPTION
Made installation in editable mode functional

- some simplifications to setup.py and removed a redundancy
- added class for the custom develop installation
- had to manually make symbolic links from miniconda env bin to the pytom clone bin
   - documented the reasons for this in setup.py, currently needed to run gpu scripts
- ran into some assertion errors, apparently assertions are always tested in dev mode
   - some of the assertions were no longer valid and had to be updated (hence the changes)

pytom can now be installed with: `pip install --editable . --prefix $CONDA_PREFIX`