### PR TITLE
convert deprecated np.int to int

### DIFF
--- a/pytom/gui/fiducialPicking.py
+++ b/pytom/gui/fiducialPicking.py
@@ -1460,7 +1460,7 @@ class PickingFunctions():
         from pytom.reconstruction.TiltAlignmentStructures import Marker
         from pytom.gui.guiFunctions import ALIGNMENT_ERRORS, fmtAE as fmt, headerAlignmentErrors
 
-        projIndices = np.arange(0, len(coordinates), 1).astype(np.int)[abs(tilt_angles) <= max_angle + 0.1]
+        projIndices = np.arange(0, len(coordinates), 1).astype(int)[abs(tilt_angles) <= max_angle + 0.1]
         Markers = []
 
         for markerID in range(coordinates.shape[1]):
@@ -1534,7 +1534,7 @@ class PickingFunctions():
         return [psiindeg, errors, shiftX, shiftY, diffX, diffY, x,y,z]
 
     def determine_markerdata(self, coordinates, errors, excluded, add_marker):
-        incl = 1- np.array(excluded,dtype=np.int)
+        incl = 1 - np.array(excluded, dtype=int)
 
         for markerID in range(coordinates.shape[1]):
             coords = coordinates[:,markerID,:]


### PR DESCRIPTION
[`np.int` has been a deprecated wrapper around python `int` for a while now](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). 
This fixes the occurence in our codebase (grepped with: `grep -r "np\.float[^0-9]" --include="*.py" --exclude-dir="build"` and `grep -r "np\.int[^0-9]" --include="*.py" --exclude-dir="build"`)