### PR TITLE
Loosen install requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM --platform=linux/amd64 continuumio/miniconda3
 WORKDIR /app
 
 # create pytom environment
-COPY environments/pytom_py3.8_cu10.6_full.yaml .
-RUN conda env create -f pytom_py3.8_cu10.6_full.yaml --name pytom_env
+COPY environments/pytom_full.yaml .
+RUN conda env create -f pytom_full.yaml --name pytom_env
 
 # activate the environment
 RUN conda init

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bash installMiniconda.sh
 Now we are ready to create the conda environment for pytom (solving all the dependencies might take a moment):
 
 ```
-conda env create -f environments/pytom_py3.8_cu10.6_full.yaml --name pytom_env
+conda env create -f environments/pytom_full.yaml --name pytom_env
 ```
 
 Activate the environment and run the pytom installation scripts to compile the backend (will take ~5 minutes):

--- a/environments/pytom_full.yaml
+++ b/environments/pytom_full.yaml
@@ -19,3 +19,5 @@ dependencies:
 - mpi4py
 - joblib
 - cupy
+- matplotlib
+- scikit-image

--- a/environments/pytom_full.yaml
+++ b/environments/pytom_full.yaml
@@ -1,0 +1,21 @@
+name: pytom_env
+channels:
+- conda-forge
+dependencies:
+- python=3
+- numpy
+- lxml
+- scipy
+- boost
+- pyqt
+- pyqtgraph
+- mrcfile
+- openmpi
+- openmpi-mpicc 
+- openmpi-mpicxx
+- openmpi-mpifort
+- numba
+- tqdm
+- mpi4py
+- joblib
+- cupy

--- a/pytom/pytomc/installFunctions.py
+++ b/pytom/pytomc/installFunctions.py
@@ -229,7 +229,7 @@ do
     fi
 done
 
-python{python_version} -O $*
+{sys.executable} -O $*
 """
 
     f = open(pytomDirectory + os.sep + 'bin' + os.sep + 'pytom','w')
@@ -240,7 +240,7 @@ python{python_version} -O $*
 
 def generatePyTomGuiScript(pytomDirectory, python_version):
     pytomguiCommand = '# !/bin/bash\n'
-    pytomguiCommand += f'python{python_version} {pytomDirectory}/gui/pytomGUI.py $1\n'
+    pytomguiCommand += f'{sys.executable} {pytomDirectory}/gui/pytomGUI.py $1\n'
 
     f = open(pytomDirectory + os.sep + 'bin' + os.sep + 'pytomGUI', 'w')
     f.write(pytomguiCommand)

--- a/tests/E2ETests/test_CCCTest.py
+++ b/tests/E2ETests/test_CCCTest.py
@@ -59,7 +59,7 @@ class pytom_MyFunctionTest(unittest.TestCase):
         check that files are written and remove them
         """
         from helper_functions import cleanUp_RandomParticleList
-        import os
+        import shutil
         # for iclass in range(0, self.settings["ncluster"]):
         #     tline = 'initial_'+str(iclass)+'.em'
         #     self.remove_file( filename=tline)
@@ -79,8 +79,8 @@ class pytom_MyFunctionTest(unittest.TestCase):
 
         self.remove_file( filename=f'{self.settings["outputDirectory"]}/correlation_matrix.csv')
 
-        cleanUp_RandomParticleList( pl_filename=self.pl_filename, pdir=self.pdir)
-        os.removedirs(self.settings["outputDirectory"])
+        cleanUp_RandomParticleList(pl_filename=self.pl_filename, pdir=self.pdir)
+        shutil.rmtree(self.settings["outputDirectory"])
 
     def remove_file(self, filename):
         """


### PR DESCRIPTION
This loosens the install requirements.

Currently it does not fail in more test than current master (`test_pytomvolume_vs_numpy.py` fails on the rotation) and the  `test_pytom_FullPipeline.py` has not been run