### PR TITLE
fix code style agnostic/filter.py

### DIFF
--- a/pytom/agnostic/correlation.py
+++ b/pytom/agnostic/correlation.py
@@ -390,7 +390,7 @@ def band_cc(
     if verbose:
         print("lowest freq : ", band[0], " highest freq", band[1])
 
-    vf, m = bandpass(volume, band[0], band[1], returnMask=True, fourierOnly=True)
+    vf, m = bandpass(volume, band[0], band[1], return_mask=True, fourierOnly=True)
     rf: xpt.NDArray = bandpass(
         reference, band[0], band[1], mask=m, fourierOnly=True
     )  # ,vf[1])
@@ -449,7 +449,7 @@ def band_cf(
 
     from math import sqrt
 
-    vf, vfm = bandpass(volume, band[0], band[1], fourierOnly=True, returnMask=True)
+    vf, vfm = bandpass(volume, band[0], band[1], fourierOnly=True, return_mask=True)
     rf = bandpass(reference, band[0], band[1], vf[1], fourierOnly=True)
 
     v = fourier_reduced2full(vf)

--- a/pytom/agnostic/correlation.py
+++ b/pytom/agnostic/correlation.py
@@ -390,9 +390,9 @@ def band_cc(
     if verbose:
         print("lowest freq : ", band[0], " highest freq", band[1])
 
-    vf, m = bandpass(volume, band[0], band[1], return_mask=True, fourierOnly=True)
+    vf, m = bandpass(volume, band[0], band[1], return_mask=True, fourier_only=True)
     rf: xpt.NDArray = bandpass(
-        reference, band[0], band[1], mask=m, fourierOnly=True
+        reference, band[0], band[1], mask=m, fourier_only=True
     )  # ,vf[1])
 
     vf = vf.astype(xp.complex128)
@@ -449,8 +449,8 @@ def band_cf(
 
     from math import sqrt
 
-    vf, vfm = bandpass(volume, band[0], band[1], fourierOnly=True, return_mask=True)
-    rf = bandpass(reference, band[0], band[1], vf[1], fourierOnly=True)
+    vf, vfm = bandpass(volume, band[0], band[1], fourier_only=True, return_mask=True)
+    rf = bandpass(reference, band[0], band[1], vf[1], fourier_only=True)
 
     v = fourier_reduced2full(vf)
     r = fourier_reduced2full(rf)

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -108,7 +108,7 @@ def bandpass(
             max(0, sz // 2 - high - 2) : min(sz, sz // 2 + high + 2),
         ]
 
-        res = fourierMult(xp.fft.fftshift(fcrop), mcrop, True)
+        res = fourier_mult(xp.fft.fftshift(fcrop), mcrop, True)
 
     else:
         res = fourier_filter(volume, mask, True)
@@ -1204,7 +1204,7 @@ def apply_fourier_filter_full(particle, filter):
     return xp.fft.ifftn(xp.fft.fftn(particle) * filter).real.astype(xp.float32)
 
 
-def fourierMult(fvolume, filter, human=False):
+def fourier_mult(fvolume, filter, human=False):
     from pytom.agnostic.transform import fourier_full2reduced
 
     if human:

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -420,7 +420,7 @@ class Wedge(object):
     def apply(self, data):
         raise NotImplementedError("Abstract method! Please overwrite it.")
 
-    def toSphericalFunc(self, bw, radius):
+    def to_spherical_func(self, bw, radius):
         raise NotImplementedError("Abstract method! Please overwrite it.")
 
 
@@ -470,7 +470,7 @@ class GeneralWedge(Wedge):
 
         return res
 
-    def toSphericalFunc(self, bw, radius):
+    def to_spherical_func(self, bw, radius):
         assert bw <= 128
 
         # start sampling
@@ -578,7 +578,7 @@ class SingleTiltWedge(Wedge):
 
         return wedge_vol
 
-    def toSphericalFunc(self, bw, radius=None, threshold=0.5):
+    def to_spherical_func(self, bw, radius=None, threshold=0.5):
         """Convert the wedge from k-space to a spherical function. \
         currently some hard-coded parameters in - bw <=128, r=45 for max bw, default vol 100
         
@@ -588,7 +588,7 @@ class SingleTiltWedge(Wedge):
 
         @return: a spherical function in numpy.array - default 100x100x100 if no self.vol defined
         """
-        assert bw <= 128, "toSphericalFunc: bw currently limited to <= 128"
+        assert bw <= 128, "to_spherical_func: bw currently limited to <= 128"
 
         # if no missing wedge
         if self.start_ang == -90 and self.end_ang == 90:

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -695,7 +695,7 @@ def create_wedge(
 
 
 def create_symmetric_wedge(
-    angle1, angle2, cutoffRadius, size_x, size_y, size_z, smooth, rotation=None
+    angle1, angle2, cutoff_radius, size_x, size_y, size_z, smooth, rotation=None
 ):
     """This function returns a symmetric wedge object.
     @param angle1: angle of wedge1 in degrees
@@ -790,14 +790,14 @@ def create_symmetric_wedge(
 
     else:
         wedge += 1
-    wedge[r > cutoffRadius] = 0
+    wedge[r > cutoff_radius] = 0
     return xp.fft.ifftshift(
         wedge, axes=(0, 1)
     )  # TODO should be ifftshift, because centered is shifted to corner
 
 
 def create_asymmetric_wedge(
-    angle1, angle2, cutoffRadius, size_x, size_y, size_z, smooth, rotation=None
+    angle1, angle2, cutoff_radius, size_x, size_y, size_z, smooth, rotation=None
 ):
     """This function returns an asymmetric wedge object.
     @param angle1: angle of wedge1 in degrees
@@ -891,7 +891,7 @@ def create_asymmetric_wedge(
         )
         wedge += strip2 * area2 * (1 - wedge) * (y <= 0)
 
-    wedge[r > cutoffRadius] = 0
+    wedge[r > cutoff_radius] = 0
 
     return xp.fft.ifftshift(
         wedge, axes=(0, 1)

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -967,7 +967,7 @@ def ramp_filter(size_x, size_y, crowther_freq=None, n=None):
     return rampfilter
 
 
-def exact_filter(tilt_angles, tiltAngle, size_x, size_y, sliceWidth, arr=[]):
+def exact_filter(tilt_angles, tiltAngle, size_x, size_y, slice_width, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
@@ -984,17 +984,17 @@ def exact_filter(tilt_angles, tiltAngle, size_x, size_y, sliceWidth, arr=[]):
     smallest_sampling = xp.min(sampling[sampling > 0.001])
 
     if (
-        sliceWidth / smallest_sampling > size_x // 2
+        slice_width / smallest_sampling > size_x // 2
     ):  # crowther crit can be to nyquist freq (i.e. sX // 2)
-        sliceWidth = smallest_sampling * (size_x // 2)  # adjust sliceWidth if too large
+        slice_width = smallest_sampling * (size_x // 2)  # adjust slice_width if too large
 
-    crowther_freq = min(size_x // 2, int(xp.ceil(sliceWidth / smallest_sampling)))
+    crowther_freq = min(size_x // 2, int(xp.ceil(slice_width / smallest_sampling)))
     arrCrowther = xp.abs(xp.arange(-crowther_freq, min(size_x // 2, crowther_freq + 1)))
 
     # as in the paper: 1 - frequency / overlap_frequency
-    # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/sliceWidth
+    # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/slice_width
     wfuncCrowther = 1.0 / xp.clip(
-        1 - ((sampling / sliceWidth)[:, xp.newaxis] * arrCrowther) ** 2, 0, 2
+        1 - ((sampling / slice_width)[:, xp.newaxis] * arrCrowther) ** 2, 0, 2
     ).sum(axis=0)
 
     # Create full width weightFunc

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -550,7 +550,7 @@ class SingleTiltWedge(Wedge):
 
         return res
 
-    def returnWedgeVolume(self, size, rotation=None):
+    def return_wedge_volume(self, size, rotation=None):
         """Return the wedge volume in full size and zero in the center
         @param size: size of wedge
         @type size: C{list}
@@ -559,7 +559,7 @@ class SingleTiltWedge(Wedge):
         @return: wedge volume
         @rtype: Numpy array
         """
-        assert len(size) == 3, "returnWedgeVolume: size must be 3-dim list"
+        assert len(size) == 3, "return_wedge_volume: size must be 3-dim list"
 
         if self._volume is not None and np.array_equal(self._volume_shape, size):
             pass

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -196,7 +196,7 @@ def wiener_filtered_ctf(ctf, ssnr, highpass=None, phaseflipped=False):
     return wiener
 
 
-def SSNR(shape, spacing_angstrom, snrfalloff, deconvstrength, r=None):
+def spatial_snr(shape, spacing_angstrom, snrfalloff, deconvstrength, r=None):
     """
 
     @param shape: shape tuple
@@ -384,7 +384,7 @@ def wiener_like_filter(
     highpass = highpass_ramp(shape, highpassnyquist)
 
     # calculate spectral SNR
-    ssnr = SSNR(shape, spacing_angstrom, snrfalloff, deconvstrength)
+    ssnr = spatial_snr(shape, spacing_angstrom, snrfalloff, deconvstrength)
 
     # calculate ctf
     ctf = -create_ctf(

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -898,12 +898,12 @@ def create_asymmetric_wedge(
     )  # TODO should be ifftshift, because centered is shifted to corner
 
 
-def circle_filter(size_x, size_y, radiusCutoff):
+def circle_filter(size_x, size_y, cutoff_radius):
     """
     circleFilter: NEEDS Documentation
     @param size_x: NEEDS Documentation
     @param size_y: NEEDS Documentation
-    @param radiusCutoff: NEEDS Documentation
+    @param cutoff_radius: NEEDS Documentation
     """
     X, Y = xp.meshgrid(
         xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2),
@@ -912,23 +912,23 @@ def circle_filter(size_x, size_y, radiusCutoff):
     R = xp.sqrt(X**2 + Y**2)
 
     filter = xp.zeros((size_x, size_y), dtype=xp.float32)
-    filter[R <= radiusCutoff] = 1
+    filter[R <= cutoff_radius] = 1
 
     return filter
 
 
-def ellipse_filter(size_x, size_y, radiusCutoffX, radiusCutoffY):
+def ellipse_filter(size_x, size_y, cutoff_radius_x, cutoff_radius_y):
     """
     circleFilter: NEEDS Documentation
     @param size_x: NEEDS Documentation
     @param size_y: NEEDS Documentation
-    @param radiusCutoff: NEEDS Documentation
+    @param cutoff_radius: NEEDS Documentation
     """
     X, Y = xp.meshgrid(
         xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2),
         xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2),
     )
-    R = xp.sqrt((X / radiusCutoffX) ** 2 + (Y / radiusCutoffY) ** 2)
+    R = xp.sqrt((X / cutoff_radius_x) ** 2 + (Y / cutoff_radius_y) ** 2)
 
     filter = xp.zeros((size_x, size_y), dtype=xp.float32)
     # print(filter.shape, R.shape)

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -497,14 +497,14 @@ class SingleTiltWedge(Wedge):
 
         self.smooth = smooth
 
-    def _create_wedge_volume(self, size, cutOffRadius=None):
-        if cutOffRadius is None:
-            cutOffRadius = size[0] // 2
+    def _create_wedge_volume(self, size, cutoff_radius=None):
+        if cutoff_radius is None:
+            cutoff_radius = size[0] // 2
 
         self._volume = create_wedge(
             self.start_ang,
             self.end_ang,
-            cutOffRadius,
+            cutoff_radius,
             size[0],
             size[1],
             size[2],
@@ -639,7 +639,7 @@ class SingleTiltWedge(Wedge):
 def create_wedge(
     wedge_angle1,
     wedge_angle2,
-    cutOffRadius,
+    cutoff_radius,
     size_x,
     size_y,
     size_z,
@@ -651,8 +651,8 @@ def create_wedge(
     @type wedge_angle1: int
     @param wedge_angle2: angle of wedge2 in degrees
     @type wedge_angle2: int
-    @param cutOffRadius: radius from center beyond which the wedge is set to zero.
-    @type cutOffRadius: int
+    @param cutoff_radius: radius from center beyond which the wedge is set to zero.
+    @type cutoff_radius: int
     @param size_x: the size of the box in x-direction.
     @type size_x: int
     @param size_y: the size of the box in y-direction.
@@ -667,14 +667,14 @@ def create_wedge(
 
     import numpy as np
 
-    if cutOffRadius < 1:
-        cutOffRadius = size_x // 2
+    if cutoff_radius < 1:
+        cutoff_radius = size_x // 2
 
     if wedge_angle1 == wedge_angle2:
         return create_symmetric_wedge(
             wedge_angle1,
             wedge_angle2,
-            cutOffRadius,
+            cutoff_radius,
             size_x,
             size_y,
             size_z,
@@ -685,7 +685,7 @@ def create_wedge(
         return create_asymmetric_wedge(
             wedge_angle1,
             wedge_angle2,
-            cutOffRadius,
+            cutoff_radius,
             size_x,
             size_y,
             size_z,
@@ -702,8 +702,8 @@ def create_symmetric_wedge(
     @type angle1: int
     @param angle2: angle of wedge2 in degrees
     @type angle2: int
-    @param cutOffRadius: radius from center beyond which the wedge is set to zero.
-    @type cutOffRadius: int
+    @param cutoff_radius: radius from center beyond which the wedge is set to zero.
+    @type cutoff_radius: int
     @param size_x: the size of the box in x-direction.
     @type size_x: int
     @param size_y: the size of the box in y-direction.
@@ -804,8 +804,8 @@ def create_asymmetric_wedge(
     @type angle1: int
     @param angle2: angle of wedge2 in degrees
     @type angle2: int
-    @param cutOffRadius: radius from center beyond which the wedge is set to zero.
-    @type cutOffRadius: int
+    @param cutoff_radius: radius from center beyond which the wedge is set to zero.
+    @type cutoff_radius: int
     @param size_x: the size of the box in x-direction.
     @type size_x: int
     @param size_y: the size of the box in y-direction.

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -62,7 +62,7 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
 
 
 def bandpass(
-    volume, low=0, high=-1, sigma=0, return_mask=False, mask=None, fourierOnly=False
+    volume, low=0, high=-1, sigma=0, return_mask=False, mask=None, fourier_only=False
 ) -> Union[Tuple[xpt.NDArray[float], xpt.NDArray[float]], xpt.NDArray[float]]:
     """Do a bandpass filter on a given volume.
 
@@ -93,7 +93,7 @@ def bandpass(
 
     from pytom.agnostic.transform import fourier_filter
 
-    if fourierOnly:
+    if fourier_only:
         fvolume = xp.fft.fftshift(volume)
         sx, sy, sz = mask.shape
 

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -937,22 +937,22 @@ def ellipse_filter(size_x, size_y, cutoff_radius_x, cutoff_radius_y):
     return filter
 
 
-def ramp_filter(size_x, size_y, crowtherFreq=None, N=None):
+def ramp_filter(size_x, size_y, crowther_freq=None, n=None):
     """
     rampFilter: Generates the weighting function required for weighted backprojection - y-axis is tilt axis
 
     @param size_x: size of weighted image in X
     @param size_y: size of weighted image in Y
-    @param crowtherFreq: size of weighted image in Y
+    @param crowther_freq: size of weighted image in Y
     @return: filter volume
 
     """
-    if crowtherFreq is None:
-        crowtherFreq = size_x // 2
-    N = 0 if N is None else 1 / N
+    if crowther_freq is None:
+        crowther_freq = size_x // 2
+    n = 0 if n is None else 1 / n
 
-    rampLine = xp.abs(xp.arange(-size_x // 2, size_x // 2)) / crowtherFreq + N
-    # should be: rampLine = xp.abs(xp.arange(-size_x // 2, size_x // 2)) / crowtherFreq + N
+    rampLine = xp.abs(xp.arange(-size_x // 2, size_x // 2)) / crowther_freq + n
+    # should be: rampLine = xp.abs(xp.arange(-size_x // 2, size_x // 2)) / crowther_freq + n
     rampLine[rampLine > 1] = 1
 
     rampfilter = xp.column_stack(
@@ -988,8 +988,8 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     ):  # crowther crit can be to nyquist freq (i.e. sX // 2)
         sliceWidth = smallest_sampling * (sX // 2)  # adjust sliceWidth if too large
 
-    crowtherFreq = min(sX // 2, int(xp.ceil(sliceWidth / smallest_sampling)))
-    arrCrowther = xp.abs(xp.arange(-crowtherFreq, min(sX // 2, crowtherFreq + 1)))
+    crowther_freq = min(sX // 2, int(xp.ceil(sliceWidth / smallest_sampling)))
+    arrCrowther = xp.abs(xp.arange(-crowther_freq, min(sX // 2, crowther_freq + 1)))
 
     # as in the paper: 1 - frequency / overlap_frequency
     # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/sliceWidth
@@ -1004,7 +1004,7 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     weightingFunc = xp.tile(wfuncCrowther, (sY, 1)).T
 
     wfunc[
-        sX // 2 - crowtherFreq : sX // 2 + min(sX // 2, crowtherFreq + 1), :
+        sX // 2 - crowther_freq : sX // 2 + min(sX // 2, crowther_freq + 1), :
     ] = weightingFunc
 
     return wfunc

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -6,9 +6,11 @@ basic filters operating on numpy arrays
 from pytom.gpu.initialize import xp, device
 import scipy
 import numpy as np
-#typing imports
+
+# typing imports
 from typing import Union, Tuple
 from pytom.gpu.initialize import xpt
+
 
 def normalize(v):
     """Normalize the data according to standard deviation
@@ -18,10 +20,11 @@ def normalize(v):
     @return: Normalized volume.
     """
     m = np.mean(v)
-    v = v-m
+    v = v - m
     s = np.std(v)
-    v = v/s
+    v = v / s
     return v
+
 
 def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
     """Do a bandpass filter on a given volume.
@@ -34,12 +37,13 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
     @return: bandpass filtered volume.
     """
     from pytom.agnostic.transform import fourier_filter
+
     assert low >= 0, "lower limit must be >= 0"
 
     from pytom.agnostic.tools import create_sphere, create_circle
 
     if high == -1:
-        high = np.min(image.shape)/2
+        high = np.min(image.shape) / 2
     assert low < high, "upper bandpass must be > than lower limit"
 
     if low == 0:
@@ -47,8 +51,9 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
     else:
         # BUG! TODO
         # the sigma
-        mask = create_circle(image.shape, high, sigma, num_sigma=5) - create_circle(image.shape, max(0,low-sigma*2),
-                                                                               sigma, num_sigma=5)
+        mask = create_circle(image.shape, high, sigma, num_sigma=5) - create_circle(
+            image.shape, max(0, low - sigma * 2), sigma, num_sigma=5
+        )
 
     if ff is None:
         res = applyFourierFilterFull(image, xp.fft.fftshift(mask))
@@ -57,7 +62,10 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
 
     return res
 
-def bandpass(volume, low=0, high=-1, sigma=0, returnMask=False, mask=None, fourierOnly=False) -> Union[Tuple[xpt.NDArray[float], xpt.NDArray[float]], xpt.NDArray[float]]:
+
+def bandpass(
+    volume, low=0, high=-1, sigma=0, returnMask=False, mask=None, fourierOnly=False
+) -> Union[Tuple[xpt.NDArray[float], xpt.NDArray[float]], xpt.NDArray[float]]:
     """Do a bandpass filter on a given volume.
 
     @param volume: input volume.
@@ -72,7 +80,7 @@ def bandpass(volume, low=0, high=-1, sigma=0, returnMask=False, mask=None, fouri
     from pytom.agnostic.tools import create_sphere
 
     if high == -1:
-        high = np.min(volume.shape)/2
+        high = np.min(volume.shape) / 2
     assert low < high, "upper bandpass must be > than lower limit"
 
     if mask is None:
@@ -81,19 +89,26 @@ def bandpass(volume, low=0, high=-1, sigma=0, returnMask=False, mask=None, fouri
         else:
             # BUG! TODO
             # the sigma
-            mask = create_sphere(volume.shape, high, sigma) - create_sphere(volume.shape, max(0,low-sigma*2), sigma)
+            mask = create_sphere(volume.shape, high, sigma) - create_sphere(
+                volume.shape, max(0, low - sigma * 2), sigma
+            )
 
     from pytom.agnostic.transform import fourier_filter
+
     if fourierOnly:
         fvolume = xp.fft.fftshift(volume)
-        sx,sy,sz = mask.shape
+        sx, sy, sz = mask.shape
 
-        fcrop = fvolume[max(0, sx // 2 - high - 2):min(sx, sx // 2 + high + 2),
-                        max(0, sy // 2 - high - 2):min(sy, sy // 2 + high + 2),
-                        max(0, sz // 2 - high - 2):min(sz, sz // 2 + high + 2) ]
-        mcrop =    mask[max(0, sx // 2 - high - 2):min(sx, sx // 2 + high + 2),
-                        max(0, sy // 2 - high - 2):min(sy, sy // 2 + high + 2),
-                        max(0, sz // 2 - high - 2):min(sz, sz // 2 + high + 2)]
+        fcrop = fvolume[
+            max(0, sx // 2 - high - 2) : min(sx, sx // 2 + high + 2),
+            max(0, sy // 2 - high - 2) : min(sy, sy // 2 + high + 2),
+            max(0, sz // 2 - high - 2) : min(sz, sz // 2 + high + 2),
+        ]
+        mcrop = mask[
+            max(0, sx // 2 - high - 2) : min(sx, sx // 2 + high + 2),
+            max(0, sy // 2 - high - 2) : min(sy, sy // 2 + high + 2),
+            max(0, sz // 2 - high - 2) : min(sz, sz // 2 + high + 2),
+        ]
 
         res = fourierMult(xp.fft.fftshift(fcrop), mcrop, True)
 
@@ -103,6 +118,7 @@ def bandpass(volume, low=0, high=-1, sigma=0, returnMask=False, mask=None, fouri
         return res, mask
     else:
         return res
+
 
 def median3d(data, size=3):
     """Median filter.
@@ -114,9 +130,11 @@ def median3d(data, size=3):
     @return: filtered image.
     """
     from scipy.ndimage.filters import median_filter
+
     assert type(size) == int, "median3d: size must be integer"
     d = median_filter(data, size)
     return d
+
 
 def gaussian3d(data, sigma=0):
     """Gaussian filter.
@@ -127,6 +145,7 @@ def gaussian3d(data, sigma=0):
     @return: filtered data.
     """
     from scipy.ndimage.filters import gaussian_filter
+
     d = gaussian_filter(data, sigma)
     return d
 
@@ -171,7 +190,9 @@ def wiener_filtered_ctf(ctf, ssnr, highpass=None, phaseflipped=False):
         ctf = xp.abs(ctf)
 
     # create the wiener_like filter
-    with np.errstate(all='ignore'):  # division by 0 is not a problem in 1/snr because the inf will be used for the
+    with np.errstate(
+        all="ignore"
+    ):  # division by 0 is not a problem in 1/snr because the inf will be used for the
         wiener = ctf / (ctf * ctf + 1 / ssnr)  # next division
     wiener[xp.isnan(wiener)] = 0
     return wiener
@@ -197,8 +218,8 @@ def SSNR(shape, spacing_angstrom, snrfalloff, deconvstrength, r=None):
     # todo what about astigmatic ssnr?
     if r is None:
         d = [xp.abs(xp.arange(size) / (size // 2) - 1) for size in shape]
-        grids = xp.meshgrid(*d, indexing='ij')
-        r = - xp.sqrt(sum([g ** 2 for g in grids]))
+        grids = xp.meshgrid(*d, indexing="ij")
+        r = -xp.sqrt(sum([g**2 for g in grids]))
 
     return xp.exp(r * snrfalloff * 100 / spacing_angstrom) * 10 ** (3 * deconvstrength)
 
@@ -218,15 +239,26 @@ def highpass_ramp(shape, highpassnyquist, r=None):
     """
     if r is None:
         d = [xp.abs(xp.arange(size) / (size // 2) - 1) for size in shape]
-        grids = xp.meshgrid(*d, indexing='ij')
-        r = xp.sqrt(sum([g ** 2 for g in grids]))
+        grids = xp.meshgrid(*d, indexing="ij")
+        r = xp.sqrt(sum([g**2 for g in grids]))
     highpass = r / highpassnyquist
     highpass[highpass > 1] = 1
     return 1 - xp.cos(highpass * xp.pi)
 
 
-def wiener_like_filter_1d(shape, spacing_angstrom, defocus, snrfalloff, deconvstrength, highpassnyquist, voltage=300e3,
-                  spherical_aberration=2.7e-3, amplitude_contrast=0.07, phaseflipped=False, phase_shift=0):
+def wiener_like_filter_1d(
+    shape,
+    spacing_angstrom,
+    defocus,
+    snrfalloff,
+    deconvstrength,
+    highpassnyquist,
+    voltage=300e3,
+    spherical_aberration=2.7e-3,
+    amplitude_contrast=0.07,
+    phaseflipped=False,
+    phase_shift=0,
+):
     """
     # todo should defocus input be in m or in um?
 
@@ -259,21 +291,34 @@ def wiener_like_filter_1d(shape, spacing_angstrom, defocus, snrfalloff, deconvst
     @author: Marten Chaillet
     """
     from pytom.simulation.microscope import create_ctf_1d
+
     size = max(shape) // 2
 
-    points_hp = xp.linspace(.0, 1., num=size)
+    points_hp = xp.linspace(0.0, 1.0, num=size)
     # points_hp = xp.arange(0, 1 + 1 / (max(shape) - 1), 1 / (max(shape) - 1))
     highpass = points_hp / highpassnyquist
     highpass[highpass > 1] = 1
     highpass = 1 - xp.cos(highpass * xp.pi)
-    points_snr = xp.linspace(.0, -1., num=size)
+    points_snr = xp.linspace(0.0, -1.0, num=size)
     # points_snr = xp.arange(0, -(1 + 1 / (max(shape) - 1)), -1 / (max(shape) - 1))
-    ssnr = xp.exp(points_snr * snrfalloff * 100 / spacing_angstrom) * 10 ** (3 * deconvstrength)
+    ssnr = xp.exp(points_snr * snrfalloff * 100 / spacing_angstrom) * 10 ** (
+        3 * deconvstrength
+    )
 
-    ctf = - create_ctf_1d(size, spacing_angstrom * 1e-10, defocus, amplitude_contrast=amplitude_contrast,
-                        voltage=voltage, Cs=spherical_aberration, phase_shift_deg=phase_shift, bfactor=.0)
+    ctf = -create_ctf_1d(
+        size,
+        spacing_angstrom * 1e-10,
+        defocus,
+        amplitude_contrast=amplitude_contrast,
+        voltage=voltage,
+        Cs=spherical_aberration,
+        phase_shift_deg=phase_shift,
+        bfactor=0.0,
+    )
 
-    wiener = wiener_filtered_ctf(ctf, ssnr, highpass=highpass, phaseflipped=phaseflipped)
+    wiener = wiener_filtered_ctf(
+        ctf, ssnr, highpass=highpass, phaseflipped=phaseflipped
+    )
 
     # now expand the wiener filter to the input shape
     # x = xp.arange(0, shape[0]) - shape[0] // 2
@@ -290,8 +335,19 @@ def wiener_like_filter_1d(shape, spacing_angstrom, defocus, snrfalloff, deconvst
     return profile2FourierVol(wiener, dim=shape)
 
 
-def wiener_like_filter(shape, spacing_angstrom, defocus, snrfalloff, deconvstrength, highpassnyquist, voltage=300e3,
-                  spherical_aberration=2.7e-3, amplitude_contrast=0.07, phaseflipped=False, phase_shift=0):
+def wiener_like_filter(
+    shape,
+    spacing_angstrom,
+    defocus,
+    snrfalloff,
+    deconvstrength,
+    highpassnyquist,
+    voltage=300e3,
+    spherical_aberration=2.7e-3,
+    amplitude_contrast=0.07,
+    phaseflipped=False,
+    phase_shift=0,
+):
     """
     # todo should defocus input be in m or in um?
     # todo function should have an option for reduced
@@ -333,12 +389,21 @@ def wiener_like_filter(shape, spacing_angstrom, defocus, snrfalloff, deconvstren
     ssnr = SSNR(shape, spacing_angstrom, snrfalloff, deconvstrength)
 
     # calculate ctf
-    ctf = - create_ctf(shape, spacing_angstrom * 1e-10, defocus, amplitude_contrast, voltage, spherical_aberration,
-                       phase_shift_deg=phase_shift)
-    print(f'ctf shape is {ctf.shape}')
+    ctf = -create_ctf(
+        shape,
+        spacing_angstrom * 1e-10,
+        defocus,
+        amplitude_contrast,
+        voltage,
+        spherical_aberration,
+        phase_shift_deg=phase_shift,
+    )
+    print(f"ctf shape is {ctf.shape}")
     # todo add astigmatism option
 
-    wiener = wiener_filtered_ctf(ctf, ssnr, highpass=highpass, phaseflipped=phaseflipped)
+    wiener = wiener_filtered_ctf(
+        ctf, ssnr, highpass=highpass, phaseflipped=phaseflipped
+    )
 
     # if reduced:
     #     z = wiener.shape[-1]
@@ -350,19 +415,21 @@ def wiener_like_filter(shape, spacing_angstrom, defocus, snrfalloff, deconvstren
 class Wedge(object):
     # TODO class not used => remove
     """Defines the missing wedge filter in Fourier space."""
+
     def __init__(self):
         super(Wedge, self).__init__()
 
     def apply(self, data):
-        raise NotImplementedError('Abstract method! Please overwrite it.')
+        raise NotImplementedError("Abstract method! Please overwrite it.")
 
     def toSphericalFunc(self, bw, radius):
-        raise NotImplementedError('Abstract method! Please overwrite it.')
+        raise NotImplementedError("Abstract method! Please overwrite it.")
 
 
 class GeneralWedge(Wedge):
     # TODO class not used => remove
     """General wedge."""
+
     def __init__(self, wedge_vol, half=True, isodd=False):
         """Initialize a general wedge with given Fourier volume.
 
@@ -378,56 +445,73 @@ class GeneralWedge(Wedge):
 
             # human understandable version with 0-freq in the center
             from transform import fourier_reduced2full, fftshift
+
             self._whole_volume = fftshift(fourier_reduced2full(self._volume, isodd))
         else:
             self._whole_volume = wedge_vol
 
             from transform import fourier_full2reduced, ifftshift
+
             self._volume = fourier_full2reduced(ifftshift(self._whole_volume))
 
     def apply(self, data, rotation=None):
-        if rotation is not None: # rotate the wedge first
+        if rotation is not None:  # rotate the wedge first
             assert len(rotation) == 3
             from transform import rotate3d, fourier_full2reduced, ifftshift
-            filter_vol = rotate3d(self._whole_volume, rotation[0], rotation[1], rotation[2], order=1)
+
+            filter_vol = rotate3d(
+                self._whole_volume, rotation[0], rotation[1], rotation[2], order=1
+            )
             filter_vol = fourier_full2reduced(ifftshift(filter_vol))
         else:
             filter_vol = self._volume
 
         from pytom.agnostic.transform import fourier_filter
+
         res = fourier_filter(data, filter_vol, False)
 
         return res
 
     def toSphericalFunc(self, bw, radius):
-        assert(bw<=128)
+        assert bw <= 128
 
         # start sampling
         from vol2sf import vol2sf
+
         sf = vol2sf(self._whole_volume, radius, bw)
-        
+
         return sf
 
 
 class SingleTiltWedge(Wedge):
     # TODO class not used => remove
     """Missing wedge of single tilt geometry. Assume Y axis is the rotation axis."""
+
     def __init__(self, start_ang=30, end_ang=30, smooth=0):
         super(SingleTiltWedge, self).__init__()
         self.start_ang = start_ang
         self.end_ang = end_ang
-        self._volume_shape = None # store the wedge volume shape (whole!)
-        self._volume = None # store the wedge volume in k-space (only half!)
+        self._volume_shape = None  # store the wedge volume shape (whole!)
+        self._volume = None  # store the wedge volume in k-space (only half!)
 
-        self._bw = None # store the bandwidth of the spherical function
-        self._sf = None # store the spherical function
+        self._bw = None  # store the bandwidth of the spherical function
+        self._sf = None  # store the spherical function
 
-        self.smooth=smooth
+        self.smooth = smooth
 
     def _create_wedge_volume(self, size, cutOffRadius=None):
-        if cutOffRadius is None: cutOffRadius = size[0]//2
+        if cutOffRadius is None:
+            cutOffRadius = size[0] // 2
 
-        self._volume = create_wedge(self.start_ang, self.end_ang, cutOffRadius, size[0], size[1], size[2], self.smooth)
+        self._volume = create_wedge(
+            self.start_ang,
+            self.end_ang,
+            cutOffRadius,
+            size[0],
+            size[1],
+            size[2],
+            self.smooth,
+        )
         self._volume_shape = size
 
     def apply(self, data, rotation=None):
@@ -443,17 +527,27 @@ class SingleTiltWedge(Wedge):
         else:
             self._create_wedge_volume(data.shape)
 
-        if rotation is not None: # rotate the wedge first
+        if rotation is not None:  # rotate the wedge first
             assert len(rotation) == 3
-            from pytom.agnostic.transform import rotate3d, fourier_reduced2full, fourier_full2reduced, fftshift, ifftshift
+            from pytom.agnostic.transform import (
+                rotate3d,
+                fourier_reduced2full,
+                fourier_full2reduced,
+                fftshift,
+                ifftshift,
+            )
+
             isodd = self._volume_shape[2] % 2
             filter_vol = fftshift(fourier_reduced2full(self._volume, isodd))
-            filter_vol = rotate3d(filter_vol, rotation[0], rotation[1], rotation[2], order=1) # linear interp!
+            filter_vol = rotate3d(
+                filter_vol, rotation[0], rotation[1], rotation[2], order=1
+            )  # linear interp!
             filter_vol = fourier_full2reduced(ifftshift(filter_vol))
         else:
             filter_vol = self._volume
 
         from pytom.agnostic.transform import fourier_filter
+
         res = fourier_filter(data, filter_vol, False)
 
         return res
@@ -468,18 +562,21 @@ class SingleTiltWedge(Wedge):
         @rtype: Numpy array
         """
         assert len(size) == 3, "returnWedgeVolume: size must be 3-dim list"
-        
+
         if self._volume is not None and np.array_equal(self._volume_shape, size):
             pass
         else:
             self._create_wedge_volume(size)
 
         from pytom.agnostic.transform import rotate3d, fourier_reduced2full, fftshift
+
         isodd = self._volume_shape[2] % 2
         wedge_vol = fftshift(fourier_reduced2full(self._volume, isodd))
-        if rotation is not None: # rotate the wedge first
+        if rotation is not None:  # rotate the wedge first
             assert len(rotation) == 3
-            wedge_vol = rotate3d(wedge_vol, rotation[0], rotation[1], rotation[2], order=1)
+            wedge_vol = rotate3d(
+                wedge_vol, rotation[0], rotation[1], rotation[2], order=1
+            )
 
         return wedge_vol
 
@@ -493,54 +590,65 @@ class SingleTiltWedge(Wedge):
 
         @return: a spherical function in numpy.array - default 100x100x100 if no self.vol defined
         """
-        assert(bw<=128), "toSphericalFunc: bw currently limited to <= 128"
+        assert bw <= 128, "toSphericalFunc: bw currently limited to <= 128"
 
         # if no missing wedge
         if self.start_ang == -90 and self.end_ang == 90:
-            self._sf = np.ones((4*bw**2,))
+            self._sf = np.ones((4 * bw**2,))
             return self._sf
 
-        r = 45 # this radius and the volume size should be sufficient for sampling b <= 128
+        r = 45  # this radius and the volume size should be sufficient for sampling b <= 128
         if self._volume is None or np.min(self._volume.shape) < 100:
-            self._create_wedge_volume((100,100,100))
-        
+            self._create_wedge_volume((100, 100, 100))
+
         if self._bw == bw and self._sf is not None:
             return self._sf
         else:
             self._bw = bw
-        
+
         from pytom.agnostic.transform import fourier_reduced2full, fftshift
+
         isodd = self._volume_shape[2] % 2
         filter_vol = fftshift(fourier_reduced2full(self._volume, isodd))
 
         # start sampling
         from math import pi, sin, cos
+
         res = []
-        
-        for j in range(2*bw):
-            for k in range(2*bw):
-                the = pi*(2*j+1)/(4*bw) # (0,pi)
-                phi = pi*k/bw # [0,2*pi)
-                
+
+        for j in range(2 * bw):
+            for k in range(2 * bw):
+                the = pi * (2 * j + 1) / (4 * bw)  # (0,pi)
+                phi = pi * k / bw  # [0,2*pi)
+
                 # this part actually needs interpolation
-                x = int(cos(phi)*sin(the)*r+50)
-                y = int(sin(phi)*sin(the)*r+50)
-                z = int(cos(the)*r+50)
-                
+                x = int(cos(phi) * sin(the) * r + 50)
+                y = int(sin(phi) * sin(the) * r + 50)
+                z = int(cos(the) * r + 50)
+
                 # if the value is bigger than the threshold, we include it
-                if filter_vol[x,y,z] > threshold:
+                if filter_vol[x, y, z] > threshold:
                     res.append(1.0)
                 else:
                     res.append(0.0)
-        
+
         # store it so that we don't have to recompute it next time
         self._sf = np.array(res)
-        
+
         return self._sf
 
 
-def create_wedge(wedge_angle1, wedge_angle2, cutOffRadius, size_x, size_y, size_z, smooth=0, rotation=None):
-    '''This function returns a wedge object. For speed reasons it decides whether to generate a symmetric or assymetric wedge.
+def create_wedge(
+    wedge_angle1,
+    wedge_angle2,
+    cutOffRadius,
+    size_x,
+    size_y,
+    size_z,
+    smooth=0,
+    rotation=None,
+):
+    """This function returns a wedge object. For speed reasons it decides whether to generate a symmetric or assymetric wedge.
     @param wedge_angle1: angle of wedge1 in degrees
     @type wedge_angle1: int
     @param wedge_angle2: angle of wedge2 in degrees
@@ -556,7 +664,7 @@ def create_wedge(wedge_angle1, wedge_angle2, cutOffRadius, size_x, size_y, size_
     @param smooth: smoothing parameter that defines the amount of smoothing  at the edge of the wedge.
     @type smooth: float
     @return: 3D array determining the wedge object.
-    @rtype: ndarray of np.float64'''
+    @rtype: ndarray of np.float64"""
     # TODO update so that uneven values for size_z still match with pytom.lib.pytom.lib.pytom_volume
 
     import numpy as np
@@ -565,12 +673,33 @@ def create_wedge(wedge_angle1, wedge_angle2, cutOffRadius, size_x, size_y, size_
         cutOffRadius = size_x // 2
 
     if wedge_angle1 == wedge_angle2:
-        return create_symmetric_wedge(wedge_angle1, wedge_angle2, cutOffRadius, size_x, size_y, size_z, smooth, rotation).astype(np.float32)
+        return create_symmetric_wedge(
+            wedge_angle1,
+            wedge_angle2,
+            cutOffRadius,
+            size_x,
+            size_y,
+            size_z,
+            smooth,
+            rotation,
+        ).astype(np.float32)
     else:
-        return create_asymmetric_wedge(wedge_angle1, wedge_angle2, cutOffRadius, size_x, size_y, size_z, smooth, rotation).astype(np.float32)
+        return create_asymmetric_wedge(
+            wedge_angle1,
+            wedge_angle2,
+            cutOffRadius,
+            size_x,
+            size_y,
+            size_z,
+            smooth,
+            rotation,
+        ).astype(np.float32)
 
-def create_symmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z, smooth, rotation=None):
-    '''This function returns a symmetric wedge object.
+
+def create_symmetric_wedge(
+    angle1, angle2, cutoffRadius, size_x, size_y, size_z, smooth, rotation=None
+):
+    """This function returns a symmetric wedge object.
     @param angle1: angle of wedge1 in degrees
     @type angle1: int
     @param angle2: angle of wedge2 in degrees
@@ -586,20 +715,22 @@ def create_symmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z,
     @param smooth: smoothing parameter that defines the amount of smoothing  at the edge of the wedge.
     @type smooth: float
     @return: 3D array determining the wedge object.
-    @rtype: ndarray of np.float64'''
+    @rtype: ndarray of np.float64"""
     wedge = xp.zeros((size_x, size_y, size_z // 2 + 1), dtype=xp.float64)
     if rotation is None:
         # numpy meshgrid by default returns indexing with cartesian coordinates (xy)
         # shape N, M, P returns meshgrid with M, N, P (see numpy meshgrid documentation)
         # the naming here is therefore weird
-        z, y, x = xp.meshgrid(xp.abs(xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2, 1.)),
-                              xp.abs(xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2, 1.)),
-                              xp.arange(0, size_z // 2 + 1, 1.))
+        z, y, x = xp.meshgrid(
+            xp.abs(xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2, 1.0)),
+            xp.abs(xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2, 1.0)),
+            xp.arange(0, size_z // 2 + 1, 1.0),
+        )
 
     else:
         # here its different again, but result is correct.
-        cx,cy,cz = [s//2 for s in (size_x,size_y,size_z)]
-        grid = xp.mgrid[-cx:size_x - cx, -cy:size_y - cy, :size_z // 2 + 1]
+        cx, cy, cz = [s // 2 for s in (size_x, size_y, size_z)]
+        grid = xp.mgrid[-cx : size_x - cx, -cy : size_y - cy, : size_z // 2 + 1]
 
         phi, the, psi = rotation
 
@@ -614,18 +745,14 @@ def create_symmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z,
         cos_gamma = xp.cos(psi)
 
         # Calculate inverse rotation matrix
-        Inv_R = xp.zeros((3, 3), dtype='float32')
+        Inv_R = xp.zeros((3, 3), dtype="float32")
 
-        Inv_R[0, 0] = cos_alpha * cos_gamma - cos_beta * sin_alpha \
-                      * sin_gamma
-        Inv_R[0, 1] = -cos_alpha * sin_gamma - cos_beta * sin_alpha \
-                      * cos_gamma
+        Inv_R[0, 0] = cos_alpha * cos_gamma - cos_beta * sin_alpha * sin_gamma
+        Inv_R[0, 1] = -cos_alpha * sin_gamma - cos_beta * sin_alpha * cos_gamma
         Inv_R[0, 2] = sin_beta * sin_alpha
 
-        Inv_R[1, 0] = sin_alpha * cos_gamma + cos_beta * cos_alpha \
-                      * sin_gamma
-        Inv_R[1, 1] = -sin_alpha * sin_gamma + cos_beta * cos_alpha \
-                      * cos_gamma
+        Inv_R[1, 0] = sin_alpha * cos_gamma + cos_beta * cos_alpha * sin_gamma
+        Inv_R[1, 1] = -sin_alpha * sin_gamma + cos_beta * cos_alpha * cos_gamma
         Inv_R[1, 2] = -sin_beta * cos_alpha
 
         Inv_R[2, 0] = sin_beta * sin_gamma
@@ -640,32 +767,41 @@ def create_symmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z,
         z = abs(grid[1, :, :, :])
         x = abs(grid[2, :, :, :])
 
-    r = xp.sqrt(x ** 2 + y ** 2 + z ** 2)
-    if angle1 > 1E-3:
-        range_angle1Smooth = smooth / xp.sin(angle1 * xp.pi / 180.)
+    r = xp.sqrt(x**2 + y**2 + z**2)
+    if angle1 > 1e-3:
+        range_angle1Smooth = smooth / xp.sin(angle1 * xp.pi / 180.0)
 
-        with np.errstate(all='ignore'):
-            wedge[xp.tan(xp.float32(angle1) * xp.pi / xp.float32(180.)) <= y / x] = 1
+        with np.errstate(all="ignore"):
+            wedge[xp.tan(xp.float32(angle1) * xp.pi / xp.float32(180.0)) <= y / x] = 1
 
         if rotation is None:
             wedge[size_x // 2, :, 0] = 1
         else:
-            phi,the,psi = rotation
-            if phi < 1E-6 and psi < 1E-6 and the<1E-6:
+            phi, the, psi = rotation
+            if phi < 1e-6 and psi < 1e-6 and the < 1e-6:
                 wedge[size_x // 2, :, 0] = 1
 
         if smooth:
             area = xp.abs(x - (y / xp.tan(angle1 * xp.pi / 180))) < range_angle1Smooth
-            strip = 1 - ((xp.abs((x) - ((y) / xp.tan(angle1 * xp.pi / 180.)))) * xp.sin(angle1 * xp.pi / 180.) / smooth)
-            wedge += (strip * area * (1 - wedge))
+            strip = 1 - (
+                (xp.abs((x) - ((y) / xp.tan(angle1 * xp.pi / 180.0))))
+                * xp.sin(angle1 * xp.pi / 180.0)
+                / smooth
+            )
+            wedge += strip * area * (1 - wedge)
 
     else:
         wedge += 1
     wedge[r > cutoffRadius] = 0
-    return xp.fft.ifftshift(wedge, axes=(0, 1))  # TODO should be ifftshift, because centered is shifted to corner
+    return xp.fft.ifftshift(
+        wedge, axes=(0, 1)
+    )  # TODO should be ifftshift, because centered is shifted to corner
 
-def create_asymmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z, smooth, rotation=None):
-    '''This function returns an asymmetric wedge object.
+
+def create_asymmetric_wedge(
+    angle1, angle2, cutoffRadius, size_x, size_y, size_z, smooth, rotation=None
+):
+    """This function returns an asymmetric wedge object.
     @param angle1: angle of wedge1 in degrees
     @type angle1: int
     @param angle2: angle of wedge2 in degrees
@@ -681,20 +817,22 @@ def create_asymmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z
     @param smooth: smoothing parameter that defines the amount of smoothing  at the edge of the wedge.
     @type smooth: float
     @return: 3D array determining the wedge object.
-    @rtype: ndarray of xp.float64'''
-    range_angle1Smooth = smooth / xp.sin(angle1 * xp.pi / 180.)
-    range_angle2Smooth = smooth / xp.sin(angle2 * xp.pi / 180.)
+    @rtype: ndarray of xp.float64"""
+    range_angle1Smooth = smooth / xp.sin(angle1 * xp.pi / 180.0)
+    range_angle2Smooth = smooth / xp.sin(angle2 * xp.pi / 180.0)
     wedge = xp.zeros((size_x, size_y, size_z // 2 + 1))
 
     if rotation is None:
         # see comment above with symmetric wedge function about meshgrid
-        z, y, x = xp.meshgrid(xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2),
-                              xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2),
-                              xp.arange(0, size_z // 2 + 1))
+        z, y, x = xp.meshgrid(
+            xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2),
+            xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2),
+            xp.arange(0, size_z // 2 + 1),
+        )
 
     else:
         cx, cy, cz = [s // 2 for s in (size_x, size_y, size_z)]
-        grid = xp.mgrid[-cx:size_x - cx, -cy:size_y - cy, :size_z // 2 + 1]
+        grid = xp.mgrid[-cx : size_x - cx, -cy : size_y - cy, : size_z // 2 + 1]
 
         phi, the, psi = rotation
 
@@ -709,18 +847,14 @@ def create_asymmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z
         cos_gamma = xp.cos(psi)
 
         # Calculate inverse rotation matrix
-        Inv_R = xp.zeros((3, 3), dtype='float32')
+        Inv_R = xp.zeros((3, 3), dtype="float32")
 
-        Inv_R[0, 0] = cos_alpha * cos_gamma - cos_beta * sin_alpha \
-                      * sin_gamma
-        Inv_R[0, 1] = -cos_alpha * sin_gamma - cos_beta * sin_alpha \
-                      * cos_gamma
+        Inv_R[0, 0] = cos_alpha * cos_gamma - cos_beta * sin_alpha * sin_gamma
+        Inv_R[0, 1] = -cos_alpha * sin_gamma - cos_beta * sin_alpha * cos_gamma
         Inv_R[0, 2] = sin_beta * sin_alpha
 
-        Inv_R[1, 0] = sin_alpha * cos_gamma + cos_beta * cos_alpha \
-                      * sin_gamma
-        Inv_R[1, 1] = -sin_alpha * sin_gamma + cos_beta * cos_alpha \
-                      * cos_gamma
+        Inv_R[1, 0] = sin_alpha * cos_gamma + cos_beta * cos_alpha * sin_gamma
+        Inv_R[1, 1] = -sin_alpha * sin_gamma + cos_beta * cos_alpha * cos_gamma
         Inv_R[1, 2] = -sin_beta * cos_alpha
 
         Inv_R[2, 0] = sin_beta * sin_gamma
@@ -735,26 +869,36 @@ def create_asymmetric_wedge(angle1, angle2, cutoffRadius, size_x, size_y, size_z
         z = grid[1, :, :, :]
         x = grid[2, :, :, :]
 
-    r = xp.sqrt(x ** 2 + y ** 2 + z ** 2)
+    r = xp.sqrt(x**2 + y**2 + z**2)
 
-
-    with np.errstate(all='ignore'):
+    with np.errstate(all="ignore"):
         wedge[xp.tan(angle1 * xp.pi / 180) < y / x] = 1
         wedge[xp.tan(-angle2 * xp.pi / 180) > y / x] = 1
     wedge[size_x // 2, :, 0] = 1
 
     if smooth:
         area = xp.abs(x - (y / xp.tan(angle1 * xp.pi / 180))) <= range_angle1Smooth
-        strip = 1 - (xp.abs(x - (y / xp.tan(angle1 * xp.pi / 180.))) * xp.sin(angle1 * xp.pi / 180.) / smooth)
-        wedge += (strip * area * (1 - wedge) * (y > 0))
+        strip = 1 - (
+            xp.abs(x - (y / xp.tan(angle1 * xp.pi / 180.0)))
+            * xp.sin(angle1 * xp.pi / 180.0)
+            / smooth
+        )
+        wedge += strip * area * (1 - wedge) * (y > 0)
 
         area2 = xp.abs(x + (y / xp.tan(angle2 * xp.pi / 180))) <= range_angle2Smooth
-        strip2 = 1 - (xp.abs(x + (y / xp.tan(angle2 * xp.pi / 180.))) * xp.sin(angle2 * xp.pi / 180.) / smooth)
-        wedge += (strip2 * area2 * (1 - wedge) * (y <= 0))
+        strip2 = 1 - (
+            xp.abs(x + (y / xp.tan(angle2 * xp.pi / 180.0)))
+            * xp.sin(angle2 * xp.pi / 180.0)
+            / smooth
+        )
+        wedge += strip2 * area2 * (1 - wedge) * (y <= 0)
 
     wedge[r > cutoffRadius] = 0
 
-    return xp.fft.ifftshift(wedge, axes=(0, 1))  # TODO should be ifftshift, because centered is shifted to corner
+    return xp.fft.ifftshift(
+        wedge, axes=(0, 1)
+    )  # TODO should be ifftshift, because centered is shifted to corner
+
 
 def circle_filter(size_x, size_y, radiusCutoff):
     """
@@ -763,13 +907,17 @@ def circle_filter(size_x, size_y, radiusCutoff):
     @param size_y: NEEDS Documentation
     @param radiusCutoff: NEEDS Documentation
     """
-    X, Y = xp.meshgrid(xp.arange(-size_x//2 + size_x%2, size_x//2+size_x%2), xp.arange(-size_y//2+size_y%2, size_y//2+size_y%2))
+    X, Y = xp.meshgrid(
+        xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2),
+        xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2),
+    )
     R = xp.sqrt(X**2 + Y**2)
 
     filter = xp.zeros((size_x, size_y), dtype=xp.float32)
     filter[R <= radiusCutoff] = 1
 
     return filter
+
 
 def ellipse_filter(size_x, size_y, radiusCutoffX, radiusCutoffY):
     """
@@ -778,14 +926,18 @@ def ellipse_filter(size_x, size_y, radiusCutoffX, radiusCutoffY):
     @param size_y: NEEDS Documentation
     @param radiusCutoff: NEEDS Documentation
     """
-    X, Y = xp.meshgrid(xp.arange(-size_y//2+size_y%2, size_y//2+size_y%2), xp.arange(-size_x//2 + size_x%2, size_x//2+size_x%2))
-    R = xp.sqrt((X/radiusCutoffX)**2 + (Y/radiusCutoffY)**2)
+    X, Y = xp.meshgrid(
+        xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2),
+        xp.arange(-size_x // 2 + size_x % 2, size_x // 2 + size_x % 2),
+    )
+    R = xp.sqrt((X / radiusCutoffX) ** 2 + (Y / radiusCutoffY) ** 2)
 
     filter = xp.zeros((size_x, size_y), dtype=xp.float32)
-    #print(filter.shape, R.shape)
+    # print(filter.shape, R.shape)
     filter[R <= 1] = 1
 
     return filter
+
 
 def ramp_filter(size_x, size_y, crowtherFreq=None, N=None):
     """
@@ -797,16 +949,25 @@ def ramp_filter(size_x, size_y, crowtherFreq=None, N=None):
     @return: filter volume
 
     """
-    if crowtherFreq is None: crowtherFreq = size_x//2
-    N = 0 if N is None else 1/N
+    if crowtherFreq is None:
+        crowtherFreq = size_x // 2
+    N = 0 if N is None else 1 / N
 
-    rampLine = xp.abs(xp.arange(-size_x//2, size_x//2)) / crowtherFreq + N
+    rampLine = xp.abs(xp.arange(-size_x // 2, size_x // 2)) / crowtherFreq + N
     # should be: rampLine = xp.abs(xp.arange(-size_x // 2, size_x // 2)) / crowtherFreq + N
     rampLine[rampLine > 1] = 1
 
-    rampfilter = xp.column_stack(([(rampLine), ] * (size_y)))
+    rampfilter = xp.column_stack(
+        (
+            [
+                (rampLine),
+            ]
+            * (size_y)
+        )
+    )
 
     return rampfilter
+
 
 def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     """
@@ -821,10 +982,12 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
 
     """
     # Calculate the relative angles in radians.
-    sampling = xp.sin(xp.abs((xp.array(tilt_angles) - tiltAngle) * xp.pi / 180.))
+    sampling = xp.sin(xp.abs((xp.array(tilt_angles) - tiltAngle) * xp.pi / 180.0))
     smallest_sampling = xp.min(sampling[sampling > 0.001])
 
-    if sliceWidth / smallest_sampling > sX // 2:  # crowther crit can be to nyquist freq (i.e. sX // 2)
+    if (
+        sliceWidth / smallest_sampling > sX // 2
+    ):  # crowther crit can be to nyquist freq (i.e. sX // 2)
         sliceWidth = smallest_sampling * (sX // 2)  # adjust sliceWidth if too large
 
     crowtherFreq = min(sX // 2, int(xp.ceil(sliceWidth / smallest_sampling)))
@@ -832,7 +995,9 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
 
     # as in the paper: 1 - frequency / overlap_frequency
     # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/sliceWidth
-    wfuncCrowther = 1. / xp.clip(1 - ((sampling / sliceWidth)[:, xp.newaxis] * arrCrowther) ** 2, 0, 2).sum(axis=0)
+    wfuncCrowther = 1.0 / xp.clip(
+        1 - ((sampling / sliceWidth)[:, xp.newaxis] * arrCrowther) ** 2, 0, 2
+    ).sum(axis=0)
 
     # Create full width weightFunc
     wfunc = xp.ones((sX, sY), dtype=xp.float32)
@@ -840,9 +1005,12 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     # row_stack is not implemented in cupy
     weightingFunc = xp.tile(wfuncCrowther, (sY, 1)).T
 
-    wfunc[sX // 2 - crowtherFreq:sX // 2 + min(sX // 2, crowtherFreq + 1), :] = weightingFunc
+    wfunc[
+        sX // 2 - crowtherFreq : sX // 2 + min(sX // 2, crowtherFreq + 1), :
+    ] = weightingFunc
 
     return wfunc
+
 
 def rotateWeighting(weighting, rotation, mask=None, binarize=False):
     """
@@ -860,19 +1028,28 @@ def rotateWeighting(weighting, rotation, mask=None, binarize=False):
     from pytom.lib.pytom_volume import vol, limit, vol_comp
     from pytom.lib.pytom_volume import rotate
     from pytom.voltools import transform
-    assert type(weighting) == vol or type(weighting) == vol_comp, "rotateWeighting: input neither vol nor vol_comp"
+
+    assert (
+        type(weighting) == vol or type(weighting) == vol_comp
+    ), "rotateWeighting: input neither vol nor vol_comp"
     from pytom.agnostic.transform import fourier_reduced2full, fourier_full2reduced
 
-    weighting = fourier_reduced2full(weighting, isodd=weighting.shape[0]%2 == 1)
+    weighting = fourier_reduced2full(weighting, isodd=weighting.shape[0] % 2 == 1)
     weighting = xp.fft.fftshift(weighting)
 
     weightingRotated = xp.zeros_like(weighting)
 
-    transform(weighting, output=weightingRotated, rotation=rotation, rotation_order='rzxz', device=device, interpolation='filt_bspline')
+    transform(
+        weighting,
+        output=weightingRotated,
+        rotation=rotation,
+        rotation_order="rzxz",
+        device=device,
+        interpolation="filt_bspline",
+    )
 
     if not mask is None:
         weightingRotated *= mask
-
 
     weightingRotated = xp.fft.fftshift(weightingRotated)
     returnVolume = fourier_full2reduced(weightingRotated)
@@ -882,6 +1059,7 @@ def rotateWeighting(weighting, rotation, mask=None, binarize=False):
         returnVolume[returnVolume >= 0.5] = 1
 
     return returnVolume
+
 
 def profile2FourierVol(profile, dim=None, reduced=False):
     """
@@ -903,13 +1081,17 @@ def profile2FourierVol(profile, dim=None, reduced=False):
 
     if dim is None:
         try:
-            dim = [2 * profile.shape[0],]*3
+            dim = [
+                2 * profile.shape[0],
+            ] * 3
         except:
-            dim = [2 * len(profile),]*3
+            dim = [
+                2 * len(profile),
+            ] * 3
 
-    is3D = (len(dim) ==  3)
+    is3D = len(dim) == 3
 
-    nx,ny = dim[:2]
+    nx, ny = dim[:2]
     if reduced:
         if is3D:
             nz = int(dim[2] // 2) + 1
@@ -919,33 +1101,42 @@ def profile2FourierVol(profile, dim=None, reduced=False):
         if is3D:
             nz = dim[2]
 
-
-
     try:
         r_max = profile.shape[0] - 1
     except:
         r_max = len(profile) - 1
 
-    if len(dim) ==3:
+    if len(dim) == 3:
         if reduced:
-            X, Y, Z = xp.meshgrid(xp.arange(-nx // 2, nx // 2 + nx % 2), xp.arange(-ny // 2, ny // 2 + ny % 2),
-                               xp.arange(0, nz))
+            X, Y, Z = xp.meshgrid(
+                xp.arange(-nx // 2, nx // 2 + nx % 2),
+                xp.arange(-ny // 2, ny // 2 + ny % 2),
+                xp.arange(0, nz),
+            )
         else:
-            X, Y, Z = xp.meshgrid(xp.arange(-nx // 2, nx // 2 + nx % 2), xp.arange(-ny // 2, ny // 2 + ny % 2),
-                               xp.arange(-nz // 2, nz // 2 + nz % 2))
-        R = xp.sqrt(X ** 2 + Y ** 2 + Z ** 2)
+            X, Y, Z = xp.meshgrid(
+                xp.arange(-nx // 2, nx // 2 + nx % 2),
+                xp.arange(-ny // 2, ny // 2 + ny % 2),
+                xp.arange(-nz // 2, nz // 2 + nz % 2),
+            )
+        R = xp.sqrt(X**2 + Y**2 + Z**2)
 
     else:
         if reduced:
             X, Y = xp.meshgrid(xp.arange(-nx // 2, ny // 2 + ny % 2), xp.arange(0, ny))
         else:
-            X, Y = xp.meshgrid(xp.arange(-nx // 2, nx // 2 + nx % 2), xp.arange(-ny // 2, ny // 2 + ny % 2))
-        R = xp.sqrt(X ** 2 + Y ** 2 )
+            X, Y = xp.meshgrid(
+                xp.arange(-nx // 2, nx // 2 + nx % 2),
+                xp.arange(-ny // 2, ny // 2 + ny % 2),
+            )
+        R = xp.sqrt(X**2 + Y**2)
 
     IR = xp.floor(R).astype(xp.int64)
     valIR_l1 = IR.copy()
     valIR_l2 = valIR_l1 + 1
-    val_l1, val_l2 = xp.zeros_like(X, dtype=xp.float64), xp.zeros_like(X, dtype=xp.float64)
+    val_l1, val_l2 = xp.zeros_like(X, dtype=xp.float64), xp.zeros_like(
+        X, dtype=xp.float64
+    )
 
     l1 = R - IR.astype(xp.float32)
     l2 = 1 - l1
@@ -954,6 +1145,7 @@ def profile2FourierVol(profile, dim=None, reduced=False):
         profile = xp.array(profile)
     except:
         import numpy
+
         profile = xp.array(numpy.array(profile))
 
     for n in xp.arange(r_max):
@@ -974,6 +1166,7 @@ def profile2FourierVol(profile, dim=None, reduced=False):
         fkernel = xp.fft.fftshift(fkernel)
 
     return fkernel
+
 
 def filter_volume_by_profile(volume, profile):
     """
@@ -999,15 +1192,20 @@ def filter_volume_by_profile(volume, profile):
     outvol = convolute(volume, kernel)
     return outvol
 
+
 def applyFourierFilter(particle, filter):
     # cast numpy to cupy if needed
     particle = xp.array(particle)
-    return xp.fft.irfftn(xp.fft.rfftn(particle, particle.shape) * filter).real.astype(xp.float32)
+    return xp.fft.irfftn(xp.fft.rfftn(particle, particle.shape) * filter).real.astype(
+        xp.float32
+    )
+
 
 def applyFourierFilterFull(particle, filter):
     # cast numpy to cupy if needed
     particle = xp.array(particle)
     return xp.fft.ifftn(xp.fft.fftn(particle) * filter).real.astype(xp.float32)
+
 
 def fourierMult(fvolume, filter, human=False):
     from pytom.agnostic.transform import fourier_full2reduced

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -967,7 +967,7 @@ def ramp_filter(size_x, size_y, crowther_freq=None, n=None):
     return rampfilter
 
 
-def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
+def exact_filter(tilt_angles, tiltAngle, size_x, size_y, sliceWidth, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
@@ -984,12 +984,12 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     smallest_sampling = xp.min(sampling[sampling > 0.001])
 
     if (
-        sliceWidth / smallest_sampling > sX // 2
+        sliceWidth / smallest_sampling > size_x // 2
     ):  # crowther crit can be to nyquist freq (i.e. sX // 2)
-        sliceWidth = smallest_sampling * (sX // 2)  # adjust sliceWidth if too large
+        sliceWidth = smallest_sampling * (size_x // 2)  # adjust sliceWidth if too large
 
-    crowther_freq = min(sX // 2, int(xp.ceil(sliceWidth / smallest_sampling)))
-    arrCrowther = xp.abs(xp.arange(-crowther_freq, min(sX // 2, crowther_freq + 1)))
+    crowther_freq = min(size_x // 2, int(xp.ceil(sliceWidth / smallest_sampling)))
+    arrCrowther = xp.abs(xp.arange(-crowther_freq, min(size_x // 2, crowther_freq + 1)))
 
     # as in the paper: 1 - frequency / overlap_frequency
     # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/sliceWidth
@@ -998,13 +998,13 @@ def exact_filter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     ).sum(axis=0)
 
     # Create full width weightFunc
-    wfunc = xp.ones((sX, sY), dtype=xp.float32)
+    wfunc = xp.ones((size_x, size_y), dtype=xp.float32)
 
     # row_stack is not implemented in cupy
-    weightingFunc = xp.tile(wfuncCrowther, (sY, 1)).T
+    weightingFunc = xp.tile(wfuncCrowther, (size_y, 1)).T
 
     wfunc[
-        sX // 2 - crowther_freq : sX // 2 + min(sX // 2, crowther_freq + 1), :
+        size_x // 2 - crowther_freq : size_x // 2 + min(size_x // 2, crowther_freq + 1), :
     ] = weightingFunc
 
     return wfunc

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -3,16 +3,15 @@
 """
 basic filters operating on numpy arrays
 """
-from pytom.gpu.initialize import xp, device
-import scipy
+# typing imports
+from typing import Tuple, Union
+
 import numpy as np
 
-# typing imports
-from typing import Union, Tuple
-from pytom.gpu.initialize import xpt
+from pytom.gpu.initialize import device, xp, xpt
 
 
-def normalize(v):
+def normalize(v: xpt.NDArray[float]) -> xpt.NDArray[float]:
     """Normalize the data according to standard deviation
 
     @param v: input volume.
@@ -36,11 +35,10 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
 
     @return: bandpass filtered volume.
     """
-    from pytom.agnostic.transform import fourier_filter
 
     assert low >= 0, "lower limit must be >= 0"
 
-    from pytom.agnostic.tools import create_sphere, create_circle
+    from pytom.agnostic.tools import create_circle
 
     if high == -1:
         high = np.min(image.shape) / 2
@@ -380,7 +378,7 @@ def wiener_like_filter(
 
     @author: Marten Chaillet
     """
-    from pytom.simulation.microscope import create_ctf, create_ctf_1d
+    from pytom.simulation.microscope import create_ctf
 
     # calculate highpass
     highpass = highpass_ramp(shape, highpassnyquist)
@@ -444,7 +442,7 @@ class GeneralWedge(Wedge):
             self._volume = wedge_vol
 
             # human understandable version with 0-freq in the center
-            from transform import fourier_reduced2full, fftshift
+            from transform import fftshift, fourier_reduced2full
 
             self._whole_volume = fftshift(fourier_reduced2full(self._volume, isodd))
         else:
@@ -457,7 +455,7 @@ class GeneralWedge(Wedge):
     def apply(self, data, rotation=None):
         if rotation is not None:  # rotate the wedge first
             assert len(rotation) == 3
-            from transform import rotate3d, fourier_full2reduced, ifftshift
+            from transform import fourier_full2reduced, ifftshift, rotate3d
 
             filter_vol = rotate3d(
                 self._whole_volume, rotation[0], rotation[1], rotation[2], order=1
@@ -530,11 +528,11 @@ class SingleTiltWedge(Wedge):
         if rotation is not None:  # rotate the wedge first
             assert len(rotation) == 3
             from pytom.agnostic.transform import (
-                rotate3d,
-                fourier_reduced2full,
-                fourier_full2reduced,
                 fftshift,
+                fourier_full2reduced,
+                fourier_reduced2full,
                 ifftshift,
+                rotate3d,
             )
 
             isodd = self._volume_shape[2] % 2
@@ -568,7 +566,7 @@ class SingleTiltWedge(Wedge):
         else:
             self._create_wedge_volume(size)
 
-        from pytom.agnostic.transform import rotate3d, fourier_reduced2full, fftshift
+        from pytom.agnostic.transform import fftshift, fourier_reduced2full, rotate3d
 
         isodd = self._volume_shape[2] % 2
         wedge_vol = fftshift(fourier_reduced2full(self._volume, isodd))
@@ -606,13 +604,13 @@ class SingleTiltWedge(Wedge):
         else:
             self._bw = bw
 
-        from pytom.agnostic.transform import fourier_reduced2full, fftshift
+        from pytom.agnostic.transform import fftshift, fourier_reduced2full
 
         isodd = self._volume_shape[2] % 2
         filter_vol = fftshift(fourier_reduced2full(self._volume, isodd))
 
         # start sampling
-        from math import pi, sin, cos
+        from math import cos, pi, sin
 
         res = []
 
@@ -1025,14 +1023,13 @@ def rotateWeighting(weighting, rotation, mask=None, binarize=False):
     @return: weight as reduced complex volume
     @rtype: L{pytom.lib.pytom_volume.vol_comp}
     """
-    from pytom.lib.pytom_volume import vol, limit, vol_comp
-    from pytom.lib.pytom_volume import rotate
+    from pytom.lib.pytom_volume import vol, vol_comp
     from pytom.voltools import transform
 
     assert (
         type(weighting) == vol or type(weighting) == vol_comp
     ), "rotateWeighting: input neither vol nor vol_comp"
-    from pytom.agnostic.transform import fourier_reduced2full, fourier_full2reduced
+    from pytom.agnostic.transform import fourier_full2reduced, fourier_reduced2full
 
     weighting = fourier_reduced2full(weighting, isodd=weighting.shape[0] % 2 == 1)
     weighting = xp.fft.fftshift(weighting)
@@ -1048,7 +1045,7 @@ def rotateWeighting(weighting, rotation, mask=None, binarize=False):
         interpolation="filt_bspline",
     )
 
-    if not mask is None:
+    if mask is not None:
         weightingRotated *= mask
 
     weightingRotated = xp.fft.fftshift(weightingRotated)

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -62,7 +62,7 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
 
 
 def bandpass(
-    volume, low=0, high=-1, sigma=0, returnMask=False, mask=None, fourierOnly=False
+    volume, low=0, high=-1, sigma=0, return_mask=False, mask=None, fourierOnly=False
 ) -> Union[Tuple[xpt.NDArray[float], xpt.NDArray[float]], xpt.NDArray[float]]:
     """Do a bandpass filter on a given volume.
 
@@ -112,7 +112,7 @@ def bandpass(
 
     else:
         res = fourier_filter(volume, mask, True)
-    if returnMask:
+    if return_mask:
         return res, mask
     else:
         return res

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -330,7 +330,7 @@ def wiener_like_filter_1d(
     # r[r > 1] = 1
     # r = xp.fft.ifftshift(r)
 
-    return profile2FourierVol(wiener, dim=shape)
+    return profile_to_fourier_vol(wiener, dim=shape)
 
 
 def wiener_like_filter(
@@ -1058,7 +1058,7 @@ def rotate_weighting(weighting, rotation, mask=None, binarize=False):
     return returnVolume
 
 
-def profile2FourierVol(profile, dim=None, reduced=False):
+def profile_to_fourier_vol(profile, dim=None, reduced=False):
     """
     create Volume from 1d radial profile, e.g., to modulate signal with \
     specific function such as CTF or FSC. Simple linear interpolation is used\
@@ -1185,7 +1185,7 @@ def filter_volume_by_profile(volume, profile):
         reduced = False
         convolute = applyFourierFilterFull
 
-    kernel = profile2FourierVol(profile=profile, dim=volume.shape, reduced=reduced)
+    kernel = profile_to_fourier_vol(profile=profile, dim=volume.shape, reduced=reduced)
     outvol = convolute(volume, kernel)
     return outvol
 

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -164,14 +164,16 @@ def wiener_filtered_ctf(ctf, ssnr, highpass=None, phaseflipped=False):
     highpass = 1 - xp.cos(highpass * xp.pi)
 
     # calculate spectral SNR
-    ssnr = xp.exp(points_snr * snrfalloff * 100 / spacing_angstrom) * 10 ** (3 * deconvstrength)
+    ssnr = xp.exp(points_snr * snrfalloff * 100 / spacing_angstrom
+           ) * 10 ** (3 * deconvstrength)
 
 
     @param ctf: ctf function
     @type  ctf: L{np.ndarray}
     @param ssnr: array with spectral signal to noise ratio, same shape as ctf
     @type  ssnr: L{np.ndarray}
-    @param highpass: Pass optional high pass filter, should filter to ~ (0.02 nm)^-1, same shape a ctf
+    @param highpass: Pass optional high pass filter, should filter to ~ (0.02 nm)^-1,
+                     same shape a ctf
     @type  highpass: L{np.ndarray}
     @param phaseflipped: Flip phases of CTF
     @type  phaseflipped: L{bool}
@@ -431,9 +433,12 @@ class GeneralWedge(Wedge):
     def __init__(self, wedge_vol, half=True, isodd=False):
         """Initialize a general wedge with given Fourier volume.
 
-        @param half: if true, the given volume is in half and zero frequency at the corner.
-                     Otherwise, the given volume is full and zero frequency in the center.
-        @param isodd: when half is true, this field tells the z dimension of the full Fourier volume is odd-/even-sized.
+        @param half: if true, 
+                        the given volume is half and has zero frequency at the corner.
+                     Otherwise, 
+                        the given volume is full and has zero frequency in the center.
+        @param isodd: when half is true, this field tells the z dimension of the full
+                      Fourier volume is odd-/even-sized.
         """
         self.set_wedge_volume(wedge_vol, half)
 
@@ -579,14 +584,17 @@ class SingleTiltWedge(Wedge):
         return wedge_vol
 
     def to_spherical_func(self, bw, radius=None, threshold=0.5):
-        """Convert the wedge from k-space to a spherical function. \
-        currently some hard-coded parameters in - bw <=128, r=45 for max bw, default vol 100
+        """Convert the wedge from k-space to a spherical function. 
+        currently has some hard-coded parameters in -
+            bw <=128, r=45 for max bw, default vol 100
         
         @param bw: bandwidth of the spherical function (must be <=128).
-        @param radius: radius in k-space. For general Wedge, not used for SingleTiltWedge.
+        @param radius: radius in k-space. 
+                       For general Wedge, not used for SingleTiltWedge.
         @param threshold: threshold, above which the value there would be set to 1.
 
-        @return: a spherical function in numpy.array - default 100x100x100 if no self.vol defined
+        @return: a spherical function in numpy.array
+                 - default 100x100x100 if no self.vol defined
         """
         assert bw <= 128, "to_spherical_func: bw currently limited to <= 128"
 
@@ -595,7 +603,8 @@ class SingleTiltWedge(Wedge):
             self._sf = np.ones((4 * bw**2,))
             return self._sf
 
-        r = 45  # this radius and the volume size should be sufficient for sampling b <= 128
+        # this radius and the volume size should be sufficient for sampling b <= 128
+        r = 45  
         if self._volume is None or np.min(self._volume.shape) < 100:
             self._create_wedge_volume((100, 100, 100))
 
@@ -646,7 +655,8 @@ def create_wedge(
     smooth=0,
     rotation=None,
 ):
-    """This function returns a wedge object. For speed reasons it decides whether to generate a symmetric or assymetric wedge.
+    """This function returns a wedge object. 
+    For speed reasons it decides whether to generate a symmetric or assymetric wedge.
     @param wedge_angle1: angle of wedge1 in degrees
     @type wedge_angle1: int
     @param wedge_angle2: angle of wedge2 in degrees
@@ -659,11 +669,13 @@ def create_wedge(
     @type size_y: int
     @param size_z: the size of the box in z-direction.
     @type size_z: int
-    @param smooth: smoothing parameter that defines the amount of smoothing  at the edge of the wedge.
+    @param smooth: smoothing parameter that defines the amount of smoothing at the edge 
+                   of the wedge.
     @type smooth: float
     @return: 3D array determining the wedge object.
     @rtype: ndarray of np.float64"""
-    # TODO update so that uneven values for size_z still match with pytom.lib.pytom.lib.pytom_volume
+    # TODO update so that uneven values for size_z still match 
+    # with pytom.lib.pytom.lib.pytom_volume
 
     import numpy as np
 
@@ -710,7 +722,8 @@ def create_symmetric_wedge(
     @type size_y: int
     @param size_z: the size of the box in z-direction.
     @type size_z: int
-    @param smooth: smoothing parameter that defines the amount of smoothing  at the edge of the wedge.
+    @param smooth: smoothing parameter that defines the amount of smoothing at the edge
+                   of the wedge.
     @type smooth: float
     @return: 3D array determining the wedge object.
     @rtype: ndarray of np.float64"""
@@ -735,12 +748,9 @@ def create_symmetric_wedge(
         phi = -float(phi) * xp.pi / 180.0
         the = -float(the) * xp.pi / 180.0
         psi = -float(psi) * xp.pi / 180.0
-        sin_alpha = xp.sin(phi)
-        cos_alpha = xp.cos(phi)
-        sin_beta = xp.sin(the)
-        cos_beta = xp.cos(the)
-        sin_gamma = xp.sin(psi)
-        cos_gamma = xp.cos(psi)
+        sin_alpha, cos_alpha = xp.sin(phi), xp.cos(phi)
+        sin_beta, cos_beta = xp.sin(the), xp.cos(the)
+        sin_gamma, cos_gamma = xp.sin(psi), xp.cos(psi)
 
         # Calculate inverse rotation matrix
         Inv_R = xp.zeros((3, 3), dtype="float32")

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -54,9 +54,9 @@ def bandpass_circle(image, low=0, high=-1, sigma=0, ff=1):
         )
 
     if ff is None:
-        res = applyFourierFilterFull(image, xp.fft.fftshift(mask))
+        res = apply_fourier_filter_full(image, xp.fft.fftshift(mask))
     else:
-        res = applyFourierFilterFull(image, xp.fft.fftshift(mask) * ff)
+        res = apply_fourier_filter_full(image, xp.fft.fftshift(mask) * ff)
 
     return res
 
@@ -1176,21 +1176,21 @@ def filter_volume_by_profile(volume, profile):
     @rtype: L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
-    from pytom.agnostic.filter import applyFourierFilter, applyFourierFilterFull
+    from pytom.agnostic.filter import apply_fourier_filter, apply_fourier_filter_full
 
     if volume.shape[0] != volume.shape[-1]:
         reduced = True
-        convolute = applyFourierFilter
+        convolute = apply_fourier_filter
     else:
         reduced = False
-        convolute = applyFourierFilterFull
+        convolute = apply_fourier_filter_full
 
     kernel = profile_to_fourier_vol(profile=profile, dim=volume.shape, reduced=reduced)
     outvol = convolute(volume, kernel)
     return outvol
 
 
-def applyFourierFilter(particle, filter):
+def apply_fourier_filter(particle, filter):
     # cast numpy to cupy if needed
     particle = xp.array(particle)
     return xp.fft.irfftn(xp.fft.rfftn(particle, particle.shape) * filter).real.astype(
@@ -1198,7 +1198,7 @@ def applyFourierFilter(particle, filter):
     )
 
 
-def applyFourierFilterFull(particle, filter):
+def apply_fourier_filter_full(particle, filter):
     # cast numpy to cupy if needed
     particle = xp.array(particle)
     return xp.fft.ifftn(xp.fft.fftn(particle) * filter).real.astype(xp.float32)

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -1010,9 +1010,9 @@ def exact_filter(tilt_angles, tilt_angle, size_x, size_y, slice_width, arr=[]):
     return wfunc
 
 
-def rotateWeighting(weighting, rotation, mask=None, binarize=False):
+def rotate_weighting(weighting, rotation, mask=None, binarize=False):
     """
-    rotateWeighting: Rotates a frequency weighting volume around the center. If the volume provided is reduced complex, it will be rescaled to full size, ftshifted, rotated, iftshifted and scaled back to reduced size.
+    rotate_weighting: Rotates a frequency weighting volume around the center. If the volume provided is reduced complex, it will be rescaled to full size, ftshifted, rotated, iftshifted and scaled back to reduced size.
     @param weighting: A weighting volume in reduced complex convention
     @type weighting: cupy or numpy array
     @param rotation: rotation angles in zxz order
@@ -1028,7 +1028,7 @@ def rotateWeighting(weighting, rotation, mask=None, binarize=False):
 
     assert (
         type(weighting) == vol or type(weighting) == vol_comp
-    ), "rotateWeighting: input neither vol nor vol_comp"
+    ), "rotate_weighting: input neither vol nor vol_comp"
     from pytom.agnostic.transform import fourier_full2reduced, fourier_reduced2full
 
     weighting = fourier_reduced2full(weighting, isodd=weighting.shape[0] % 2 == 1)

--- a/pytom/agnostic/filter.py
+++ b/pytom/agnostic/filter.py
@@ -967,7 +967,7 @@ def ramp_filter(size_x, size_y, crowther_freq=None, n=None):
     return rampfilter
 
 
-def exact_filter(tilt_angles, tiltAngle, size_x, size_y, slice_width, arr=[]):
+def exact_filter(tilt_angles, tilt_angle, size_x, size_y, slice_width, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
@@ -980,7 +980,7 @@ def exact_filter(tilt_angles, tiltAngle, size_x, size_y, slice_width, arr=[]):
 
     """
     # Calculate the relative angles in radians.
-    sampling = xp.sin(xp.abs((xp.array(tilt_angles) - tiltAngle) * xp.pi / 180.0))
+    sampling = xp.sin(xp.abs((xp.array(tilt_angles) - tilt_angle) * xp.pi / 180.0))
     smallest_sampling = xp.min(sampling[sampling > 0.001])
 
     if (

--- a/pytom/agnostic/io.py
+++ b/pytom/agnostic/io.py
@@ -1918,13 +1918,13 @@ def readSubvolumeFromFourierspaceFile(filename, size_x, size_y, size_z):
     Works only if fourier file is reduced complex without any shift applied.
     @param filename: The fourier space file name
     @param size_x: X final size of subvolume if it was complete
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume} with
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume} with
     humanUnderstandable == True returns)
     @param size_y: Y final size of subvolume if it was complete
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume}
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume}
     with humanUnderstandable == True returns)
     @param size_z: Z final size of subvolume if it was complete
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume}
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume}
     with humanUnderstandable == True returns)
     @return: A subvolume
     @author: Thomas Hrabe

--- a/pytom/agnostic/particle.py
+++ b/pytom/agnostic/particle.py
@@ -134,7 +134,7 @@ class ParticleList(BaseClass):
             v = p.getTransformedVolume()
             # apply wedge to the volume itself
             v = p.wedge.apply(v, [-p.rotation_psi, -p.rotation_phi, -p.rotation_the])
-            w = p.wedge.returnWedgeVolume(v.shape, [-p.rotation_psi, -p.rotation_phi, -p.rotation_the])
+            w = p.wedge.return_wedge_volume(v.shape, [-p.rotation_psi, -p.rotation_phi, -p.rotation_the])
             if v_sum is None:
                 v_sum = v
                 wedge_sum = w

--- a/pytom/agnostic/reconstruction_functions.py
+++ b/pytom/agnostic/reconstruction_functions.py
@@ -123,15 +123,15 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     # Closest angle to tiltAngle (but not tiltAngle) sets the maximal frequency of overlap (Crowther's frequency).
     # Weights only need to be calculated up to this frequency.
     sampling = min(abs(diffAngles)[abs(diffAngles) > 0.001])
-    crowtherFreq = min(sX // 2, int(ceil(1 / sin(sampling))))
-    arrCrowther = matrix(abs(arange(-crowtherFreq, min(sX // 2, crowtherFreq + 1))))
+    crowther_freq = min(sX // 2, int(ceil(1 / sin(sampling))))
+    arrCrowther = matrix(abs(arange(-crowther_freq, min(sX // 2, crowther_freq + 1))))
 
     # Calculate weights
     wfuncCrowther = 1. / (clip(1 - array(matrix(abs(sin(diffAngles))).T * arrCrowther) ** 2, 0, 2)).sum(axis=0)
 
     # Create full with weightFunc
     wfunc = ones((sX, sY, 1), dtype=float32)
-    wfunc[sX // 2 - crowtherFreq:sX // 2 + min(sX // 2, crowtherFreq + 1), :, 0] = column_stack(
+    wfunc[sX // 2 - crowther_freq:sX // 2 + min(sX // 2, crowther_freq + 1), :, 0] = column_stack(
         ([(wfuncCrowther), ] * (sY))).astype(float32)
     return wfunc
 

--- a/pytom/agnostic/reconstruction_functions.py
+++ b/pytom/agnostic/reconstruction_functions.py
@@ -93,14 +93,14 @@ def backProjectGPU(projections, reconstruction, vol_phi, proj_angles, recPosVol=
                                                             center_recon, dims, tr, reconstruction.size))
 
 
-def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
+def exactFilter(tilt_angles, tilt_angle, sX, sY, slice_width, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
     @param tilt_angles: List of tilt angles
     @type tilt_angles: list  of floats
-    @param tiltAngle: Tilt angle of projection
-    @type tiltAngle: float
+    @param tilt_angle: Tilt angle of projection
+    @type tilt_angle: float
     @param sX: size of the x-axis
     @type sX: int
     @param sY: size of the y-axis
@@ -118,9 +118,9 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
     # sY = sY // 2 + 1
 
     # Calculate the relative angles in radians.
-    diffAngles = (array(tilt_angles) - tiltAngle) * pi / 180.
+    diffAngles = (array(tilt_angles) - tilt_angle) * pi / 180.
 
-    # Closest angle to tiltAngle (but not tiltAngle) sets the maximal frequency of overlap (Crowther's frequency).
+    # Closest angle to tilt_angle (but not tilt_angle) sets the maximal frequency of overlap (Crowther's frequency).
     # Weights only need to be calculated up to this frequency.
     sampling = min(abs(diffAngles)[abs(diffAngles) > 0.001])
     crowther_freq = min(sX // 2, int(ceil(1 / sin(sampling))))

--- a/pytom/agnostic/reconstruction_functions.py
+++ b/pytom/agnostic/reconstruction_functions.py
@@ -93,7 +93,7 @@ def backProjectGPU(projections, reconstruction, vol_phi, proj_angles, recPosVol=
                                                             center_recon, dims, tr, reconstruction.size))
 
 
-def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
+def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
@@ -105,8 +105,8 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     @type sX: int
     @param sY: size of the y-axis
     @type sY: int
-    @param sliceWidth: width slice through the object
-    @type sliceWidth: int
+    @param slice_width: width slice through the object
+    @type slice_width: int
     @param arr: array
     @type arr: list
     @return: 2D weight array of floats

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -1068,7 +1068,7 @@ class Wedge(PyTomClass):
     Wedge: used as an dummy class to distinguish between single tilt axis wedge and double tilt axis wedge in fromXML
     """
 
-    def __init__(self, wedge_angles=[0.0, 0.0], cutoffRadius=0.0, tiltAxis='Y', smooth=0.0, wedge_3d_ctf_file='',
+    def __init__(self, wedge_angles=[0.0, 0.0], cutoff_radius=0.0, tiltAxis='Y', smooth=0.0, wedge_3d_ctf_file='',
                  ctf_max_resolution=0.):
         """
         __init__: This constructor is compatible to L{pytom.agnostic.structures.SingleTiltWedge} and L{pytom.agnostic.structures.DoubleTiltWedge}.
@@ -1083,7 +1083,7 @@ class Wedge(PyTomClass):
                 if wedge_angles.__class__ == list and wedge_angles[0].__class__ == list and len(wedge_angles[0]) == 2 and \
                         wedge_angles[1].__class__ == list and len(wedge_angles[1]) == 2:
                     self._wedgeObject = DoubleTiltWedge(wedge_angles=wedge_angles, tiltAxis1='Y', rotation12=tiltAxis,
-                                                        cutoffRadius=cutoffRadius, smooth=smooth)
+                                                        cutoff_radius=cutoff_radius, smooth=smooth)
                     self._type = 'DoubleTiltWedge'
                 else:
 
@@ -1091,7 +1091,7 @@ class Wedge(PyTomClass):
             except:
                 if wedge_angles.__class__ == list and wedge_angles[0].__class__ == list and wedge_angles[1].__class__ == list:
                     raise TypeError('Wrong parameters for SingleTiltWedge object error thrown by Wedge object!')
-                self._wedgeObject = SingleTiltWedge(wedge_angles, cutoffRadius=cutoffRadius, tiltAxis=tiltAxis,
+                self._wedgeObject = SingleTiltWedge(wedge_angles, cutoff_radius=cutoff_radius, tiltAxis=tiltAxis,
                                                     smooth=smooth)
                 self._type = 'SingleTiltWedge'
 
@@ -1246,14 +1246,14 @@ class SingleTiltWedge(PyTomClass):
     @author: Thomas Hrabe
     """
 
-    def __init__(self, wedge_angle=0.0, rotation=None, cutoffRadius=0.0, tiltAxis='Y', smooth=0.0):
+    def __init__(self, wedge_angle=0.0, rotation=None, cutoff_radius=0.0, tiltAxis='Y', smooth=0.0):
         """
         @param wedge_angle: The wedge angle. In wedge halfs.
         @type wedge_angle: either float (for symmetric wedge) or [float,float]  for \
             asymmetric wedge.
         @param rotation: deprecated!!! Only leave it here for compatibility reason.
         @deprecated: rotation
-        @param cutoffRadius: Maximum frequency (in pixels) up to where wedge will \
+        @param cutoff_radius: Maximum frequency (in pixels) up to where wedge will \
             be generated. If omitted / 0, filter is fixed to size/2.
         @param tiltAxis: Default will be Y. You can choose between the strings "X",\
             "Y" or "custom". You can also specify a Rotation object
@@ -1272,7 +1272,7 @@ class SingleTiltWedge(PyTomClass):
 
         if rotation:
             pass  # print("average: Warning - input rotation will not be used because deprecated!")
-        self._cutoffRadius = cutoffRadius
+        self._cutoff_radius = cutoff_radius
         self._tiltAxisRotation = Rotation(0.0, 0.0, 0.0)
 
         if tiltAxis.__class__ == str:
@@ -1333,10 +1333,10 @@ class SingleTiltWedge(PyTomClass):
         @author: Thomas Hrabe
         """
         # This import from own file ....
-        if self._cutoffRadius == 0.0:
+        if self._cutoff_radius == 0.0:
             cut = wedgeSizeX // 2
         else:
-            cut = self._cutoffRadius
+            cut = self._cutoff_radius
         weightObject = Weight(self._wedge_angle1, self._wedge_angle2, cut, wedgeSizeX, wedgeSizeY, wedgeSizeZ,
                               self._smooth)
 
@@ -1439,7 +1439,7 @@ class SingleTiltWedge(PyTomClass):
             self._wedge_angle1 = float(xmlObj.get('Angle1'))
             self._wedge_angle2 = float(xmlObj.get('Angle2'))
 
-        self._cutoffRadius = float(xmlObj.get('CutoffRadius'))
+        self._cutoff_radius = float(xmlObj.get('CutoffRadius'))
 
         if (xmlObj.get('Smooth') != None):
             self._smooth = float(xmlObj.get('Smooth'))
@@ -1464,7 +1464,7 @@ class SingleTiltWedge(PyTomClass):
         from lxml import etree
 
         wedgeElement = etree.Element('SingleTiltWedge', Angle1=str(self._wedge_angle1),
-                                     Angle2=str(self._wedge_angle2), CutoffRadius=str(self._cutoffRadius),
+                                     Angle2=str(self._wedge_angle2), CutoffRadius=str(self._cutoff_radius),
                                      Smooth=str(self._smooth))
 
         if ((not isinstance(self._tiltAxisRotation, int)) or
@@ -1497,7 +1497,7 @@ class DoubleTiltWedge(SingleTiltWedge):
     DoubleTiltWedge: Represents a wedge determined for a double tilt series of projections
     """
 
-    def __init__(self, wedge_angles=[[0, 0], [0, 0]], tiltAxis1='Y', rotation12=[90, 0, 0], cutoffRadius=0.0,
+    def __init__(self, wedge_angles=[[0, 0], [0, 0]], tiltAxis1='Y', rotation12=[90, 0, 0], cutoff_radius=0.0,
                  smooth=0.0):
         """Initialize a double tilt wedge
         @param wedge_angles: List of the tilt parameters [[tilt1.1,tilt1.2],[tilt2.1,tilt2.2]]. \
@@ -1509,7 +1509,7 @@ be set to X -> the double tilt wedge is perfectly rotated by 90 degrees.
 L{pytom.agnostic.structures.Rotation}
         @param rotation12: Rotation of 2nd tilt series with respect to 1st
         @type rotation12: rotation object L{pytom.agnostic.structures.Rotation} or 3-dim list
-        @param cutoffRadius: Maximum frequency (in pixels) up to where wedge will \
+        @param cutoff_radius: Maximum frequency (in pixels) up to where wedge will \
 be generated. If omitted / 0, filter is fixed to size/2.
         @param smooth: Smoothing size of wedge at the edges in degrees. Default is 0.
         """
@@ -1545,8 +1545,8 @@ be generated. If omitted / 0, filter is fixed to size/2.
 
         tiltAxis2 = (rotation12 * tiltAxis1)
 
-        self._wedge1 = SingleTiltWedge(tilt1, None, cutoffRadius, tiltAxis=tiltAxis1, smooth=smooth)
-        self._wedge2 = SingleTiltWedge(tilt2, None, cutoffRadius, tiltAxis=tiltAxis2, smooth=smooth)
+        self._wedge1 = SingleTiltWedge(tilt1, None, cutoff_radius, tiltAxis=tiltAxis1, smooth=smooth)
+        self._wedge2 = SingleTiltWedge(tilt2, None, cutoff_radius, tiltAxis=tiltAxis2, smooth=smooth)
 
         # for FRM
         self._wedge_vol = None  # cache for storing the wedge volume

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -4927,7 +4927,7 @@ class BandPassFilter(PyTomClass):
             print("Warning: Highest frequency in bandpass is larger than volume size.")
 
         res = bandpassFilter(volume, self._lowestFrequency, self._highestFrequency, bpf=None, smooth=self._smooth,
-                             fourierOnly=False)
+                             fourier_only=False)
         return res[0]
 
 

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -808,7 +808,7 @@ class Reference(PyTomClass):
 
         from pytom.agnostic.io import read
         from pytom.gpu.gpuFunctions import applyFourierFilter as convolute
-        from pytom.agnostic.filter import rotateWeighting
+        from pytom.agnostic.filter import rotate_weighting
         from pytom.agnostic.tools import invert_WedgeSum
         from pytom.agnostic.filter import filter_volume_by_profile
         from pytom.basic.resolution import read_fscFromAscii
@@ -835,7 +835,7 @@ class Reference(PyTomClass):
             wedge = particleWedge.return_wedge_volume(ptx, pty, ptz, False, rotinvert)
             # < buggy version
         else:
-            wedge = rotateWeighting(particleWedge.return_wedge_volume(ptx, pty, ptz, False),
+            wedge = rotate_weighting(particleWedge.return_wedge_volume(ptx, pty, ptz, False),
                                     [rotinvert[0], rotinvert[2],rotinvert[1]], mask=None)
 
 

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -832,10 +832,10 @@ class Reference(PyTomClass):
         rotinvert = particleRotation.invert()
         if analytWedge:
             # > buggy version
-            wedge = particleWedge.returnWedgeVolume(ptx, pty, ptz, False, rotinvert)
+            wedge = particleWedge.return_wedge_volume(ptx, pty, ptz, False, rotinvert)
             # < buggy version
         else:
-            wedge = rotateWeighting(particleWedge.returnWedgeVolume(ptx, pty, ptz, False),
+            wedge = rotateWeighting(particleWedge.return_wedge_volume(ptx, pty, ptz, False),
                                     [rotinvert[0], rotinvert[2],rotinvert[1]], mask=None)
 
 
@@ -1111,10 +1111,10 @@ class Wedge(PyTomClass):
         else:
             return self._wedgeObject.returnWedgeFilter(wedgeSizeX, wedgeSizeY, wedgeSizeZ, rotation)
 
-    def returnWedgeVolume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
+    def return_wedge_volume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
                           rotation=None):
         """
-        returnWedgeVolume: Returns a wedge volume for later processing.
+        return_wedge_volume: Returns a wedge volume for later processing.
         @param wedgeSizeX: volume size for x (size of original volume in real space)
         @param wedgeSizeY: volume size for y (size of original volume in real space)
         @param wedgeSizeZ: volume size for z (size of original volume in real space)
@@ -1125,7 +1125,7 @@ class Wedge(PyTomClass):
         @author: Thomas Hrabe
         """
 
-        return self._wedgeObject.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
+        return self._wedgeObject.return_wedge_volume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
 
     def getWedgeAngle(self):
         """
@@ -1349,9 +1349,9 @@ class SingleTiltWedge(PyTomClass):
 
         return weightObject
 
-    def returnWedgeVolume(self, wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable=False, rotation=None):
+    def return_wedge_volume(self, wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable=False, rotation=None):
         """
-        returnWedgeVolume: Returns a wedge volume for later processing.
+        return_wedge_volume: Returns a wedge volume for later processing.
         @param wedgeSizeX: volume size for x (size of original volume in real space)
         @param wedgeSizeY: volume size for y (size of original volume in real space)
         @param wedgeSizeZ: volume size for z (size of original volume in real space)
@@ -1403,7 +1403,7 @@ class SingleTiltWedge(PyTomClass):
         if self._wedge_angle1 > 0 or self._wedge_angle2 > 0:
             from pytom.agnostic.filter import applyFourierFilter as filter
 
-            wedgeFilter = self.returnWedgeVolume(volume.shape[0], volume.shape[1], volume.shape[2], rotation)
+            wedgeFilter = self.return_wedge_volume(volume.shape[0], volume.shape[1], volume.shape[2], rotation)
             result = filter(volume, wedgeFilter)
 
             return result
@@ -1553,9 +1553,9 @@ be generated. If omitted / 0, filter is fixed to size/2.
         self._bw = None
         self._sf = None
 
-    def returnWedgeVolume(self, wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable=False, rotation=None):
+    def return_wedge_volume(self, wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable=False, rotation=None):
         """
-        returnWedgeVolume: Returns a wedge volume for later processing.
+        return_wedge_volume: Returns a wedge volume for later processing.
         @param wedgeSizeX: volume size for x (size of original volume in real space)
         @param wedgeSizeY: volume size for y (size of original volume in real space)
         @param wedgeSizeZ: volume size for z (size of original volume in real space)
@@ -1567,8 +1567,8 @@ be generated. If omitted / 0, filter is fixed to size/2.
         @author: Thomas Hrabe
         """
 
-        w1 = self._wedge1.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
-        w2 = self._wedge2.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
+        w1 = self._wedge1.return_wedge_volume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
+        w2 = self._wedge2.return_wedge_volume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
 
         # combine into one
         w = w1 + w2
@@ -1638,7 +1638,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
         if not volume.__class__ == xp.array:
             raise TypeError('You must provide a pytom.lib.pytom_volume.vol here!')
 
-        wedgeVolume = self.returnWedgeVolume(volume.size_x(), volume.size_y(), volume.size_z(),
+        wedgeVolume = self.return_wedge_volume(volume.size_x(), volume.size_y(), volume.size_z(),
                                              humanUnderstandable=False, rotation=rotation)
 
         result = applyFourierFilter(volume, wedgeVolume)
@@ -1678,7 +1678,7 @@ class Wedge3dCTF(PyTomClass):
     def set_ctf_max_resolution(self, ctf_max_resolution):
         self._ctf_max_resolution = ctf_max_resolution
 
-    def returnWedgeVolume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
+    def return_wedge_volume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
                           rotation=None):
         """parameters here are not needed but for compat with the wedge class"""
         if wedgeSizeX is not None or wedgeSizeY is not None or wedgeSizeZ is not None:
@@ -1699,7 +1699,7 @@ class Wedge3dCTF(PyTomClass):
         if volume.__class__ is not xp.ndarray:
             raise TypeError('Wedge3dCTF: You must provide a numpy/cupy array here!')
 
-        wedge = self.returnWedgeVolume()
+        wedge = self.return_wedge_volume()
 
         return applyFourierFilter(volume, wedge)
 
@@ -1775,7 +1775,7 @@ class GeneralWedge(PyTomClass):
 
         return w
 
-    def returnWedgeVolume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
+    def return_wedge_volume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
                           rotation=None):
         wedgeFilter = self.returnWedgeFilter(None, None, None, rotation)
 
@@ -3314,9 +3314,9 @@ class ParticleList(PyTomClass):
             # rotate the wedge
             w = p.getWedge()
             if sum_w is None:
-                sum_w = w.returnWedgeVolume(v.shape[0], v.shape[1], v.shape[2], False, p.getRotation().invert())
+                sum_w = w.return_wedge_volume(v.shape[0], v.shape[1], v.shape[2], False, p.getRotation().invert())
             else:
-                sum_w += w.returnWedgeVolume(v.shape[0], v.shape[1], v.shape[2], False, p.getRotation().invert())
+                sum_w += w.return_wedge_volume(v.shape[0], v.shape[1], v.shape[2], False, p.getRotation().invert())
 
             # calculate the variance
             wa = w.apply(average, p.getRotation().invert())

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -4932,10 +4932,10 @@ class BandPassFilter(PyTomClass):
 
 
 class Weight():
-    def __init__(self, wedge_angle1=0, wedge_angle2=0, cutOffRadius=0, size_x=0, size_y=0, size_z=0, smooth=0, rotation=None):
+    def __init__(self, wedge_angle1=0, wedge_angle2=0, cutoff_radius=0, size_x=0, size_y=0, size_z=0, smooth=0, rotation=None):
         self.wedge_angle1 = wedge_angle1
         self.wedge_angle2 = wedge_angle2
-        self.cutOffRadius = cutOffRadius
+        self.cutoff_radius = cutoff_radius
         self.size_x = size_x
         self.size_y = size_y
         self.size_z = size_z
@@ -4956,7 +4956,7 @@ class Weight():
         from pytom.agnostic.filter import create_wedge
         from pytom.agnostic.transform import fourier_reduced2full
 
-        wedge = create_wedge(self.wedge_angle1, self.wedge_angle2, self.cutOffRadius, self.size_x, self.size_y, self.size_z, self.smooth, self.rotation)
+        wedge = create_wedge(self.wedge_angle1, self.wedge_angle2, self.cutoff_radius, self.size_x, self.size_y, self.size_z, self.smooth, self.rotation)
 
         if reducedComplex == False:
             wedge = fourier_reduced2full(wedge)

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -1158,13 +1158,13 @@ class Wedge(PyTomClass):
         """
         return self._wedgeObject
 
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
         @return: a spherical function in numpy.array
         """
-        return self._wedgeObject.toSphericalFunc(b, radius)
+        return self._wedgeObject.to_spherical_func(b, radius)
 
     def toXML(self):
 
@@ -1410,7 +1410,7 @@ class SingleTiltWedge(PyTomClass):
         else:
             return volume
 
-    def toSphericalFunc(self, b, radius=None):
+    def to_spherical_func(self, b, radius=None):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
@@ -1579,7 +1579,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
 
         return w
 
-    def toSphericalFunc(self, b, radius=None):
+    def to_spherical_func(self, b, radius=None):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
@@ -1703,7 +1703,7 @@ class Wedge3dCTF(PyTomClass):
 
         return applyFourierFilter(volume, wedge)
 
-    def toSphericalFunc(self, b, radius=None):
+    def to_spherical_func(self, b, radius=None):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
@@ -1802,7 +1802,7 @@ class GeneralWedge(PyTomClass):
         result = filter(volume, wedgeFilter)
         return result
 
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.

--- a/pytom/agnostic/structures.py
+++ b/pytom/agnostic/structures.py
@@ -2,7 +2,7 @@ from pytom.gpu.initialize import xp, device
 from pytom.basic.structures import Rotation as RotationPytomC
 from pytom.agnostic.io import read
 from pytom.agnostic.transform import fftshift, fourier_reduced2full
-from pytom.agnostic.filter import applyFourierFilter
+from pytom.agnostic.filter import apply_fourier_filter
 
 
 class PyTomClassError(Exception):
@@ -293,12 +293,12 @@ class Preprocessing(PyTomClass):
         if self._weightingOn and (not bypassFlag):
             from pytom.agnostic.io import read
             from pytom.agnostic.structures import Weight as weight
-            from pytom.agnostic.filter import applyFourierFilter
+            from pytom.agnostic.filter import apply_fourier_filter
 
             # TODO What exactly is read here? I interpreted this as a volume
             wedgeSum = read(self._weightingFile)
 
-            applyFourierFilter(volume, wedgeSum)
+            apply_fourier_filter(volume, wedgeSum)
 
         if self._substractParticle and particle.__class__ == vol:
             volume -= particle
@@ -807,7 +807,7 @@ class Reference(PyTomClass):
         # if flag is set and both files exist, do subtract particle from reference
 
         from pytom.agnostic.io import read
-        from pytom.gpu.gpuFunctions import applyFourierFilter as convolute
+        from pytom.gpu.gpuFunctions import apply_fourier_filter as convolute
         from pytom.agnostic.filter import rotate_weighting
         from pytom.agnostic.tools import invert_WedgeSum
         from pytom.agnostic.filter import filter_volume_by_profile
@@ -1401,7 +1401,7 @@ class SingleTiltWedge(PyTomClass):
             raise TypeError('SingleTiltWedge: You must provide a xp.array here!')
 
         if self._wedge_angle1 > 0 or self._wedge_angle2 > 0:
-            from pytom.agnostic.filter import applyFourierFilter as filter
+            from pytom.agnostic.filter import apply_fourier_filter as filter
 
             wedgeFilter = self.return_wedge_volume(volume.shape[0], volume.shape[1], volume.shape[2], rotation)
             result = filter(volume, wedgeFilter)
@@ -1633,7 +1633,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
         @rtype: L{pytom.lib.pytom_volume.vol}
         @author: Thomas Hrabe
         """
-        from pytom.agnostic.filter import applyFourierFilter
+        from pytom.agnostic.filter import apply_fourier_filter
 
         if not volume.__class__ == xp.array:
             raise TypeError('You must provide a pytom.lib.pytom_volume.vol here!')
@@ -1641,7 +1641,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
         wedgeVolume = self.return_wedge_volume(volume.size_x(), volume.size_y(), volume.size_z(),
                                              humanUnderstandable=False, rotation=rotation)
 
-        result = applyFourierFilter(volume, wedgeVolume)
+        result = apply_fourier_filter(volume, wedgeVolume)
 
         return result
 
@@ -1701,7 +1701,7 @@ class Wedge3dCTF(PyTomClass):
 
         wedge = self.return_wedge_volume()
 
-        return applyFourierFilter(volume, wedge)
+        return apply_fourier_filter(volume, wedge)
 
     def to_spherical_func(self, b, radius=None):
         """Convert the wedge from real space to a spherical function.
@@ -1797,7 +1797,7 @@ class GeneralWedge(PyTomClass):
         if not volume.__class__ == xp.array:
             raise TypeError('You must provide a xp.ndarray here!')
 
-        from pytom.agnostic.filter import applyFourierFilter as filter
+        from pytom.agnostic.filter import apply_fourier_filter as filter
         wedgeFilter = self.returnWedgeFilter(None, None, None, rotation)
         result = filter(volume, wedgeFilter)
         return result
@@ -3299,7 +3299,7 @@ class ParticleList(PyTomClass):
         """
         from pytom.lib.pytom_volume import variance
         from pytom.tools.ProgressBar import FixedProgBar
-        from pytom.agnostic.filter import applyFourierFilter
+        from pytom.agnostic.filter import apply_fourier_filter
 
         if verbose:
             progressBar = FixedProgBar(0, len(self._particleList), '')
@@ -3337,7 +3337,7 @@ class ParticleList(PyTomClass):
                 progressBar.update(num_processed)
 
         # take care the wedge weighting
-        result = applyFourierFilter(sum_var, 1/sum_w)
+        result = apply_fourier_filter(sum_var, 1/sum_w)
 
         return result
 
@@ -4946,11 +4946,11 @@ class Weight():
         self.rotation = [phi, theta, psi]
 
     def apply(self, volume):
-        from pytom.agnostic.filter import applyFourierFilter
+        from pytom.agnostic.filter import apply_fourier_filter
 
         wedge = self.getWeightVolume()
 
-        return applyFourierFilter(volume, wedge)
+        return apply_fourier_filter(volume, wedge)
 
     def getWeightVolume(self, reducedComplex=True):
         from pytom.agnostic.filter import create_wedge

--- a/pytom/alignment/GLocalSampling.py
+++ b/pytom/alignment/GLocalSampling.py
@@ -315,7 +315,7 @@ def mainAlignmentLoop(alignmentJob, verbose=False):
             remove(alignmentJob.destination+"/"+'CurrentMask.xml')
 
         else:
-            from pytom.gpu.gpuFunctions import applyFourierFilter
+            from pytom.gpu.gpuFunctions import apply_fourier_filter
             from pytom.agnostic.io import read
             print(">>>>>>>>> Aligning Even ....")
             resultsEven = mpi.parfor(alignParticleListGPU, list(zip(evenSplitList,
@@ -404,7 +404,7 @@ def mainAlignmentLoop(alignmentJob, verbose=False):
                 # # write(fname3, average)
                 # # write(fname2, weight)
                 #
-                #write(fname, applyFourierFilter(average, weight))
+                #write(fname, apply_fourier_filter(average, weight))
                 # average *= 0
                 # weight *= 0
                 cvols[name] = read(fname)
@@ -856,12 +856,12 @@ def averageParallel(particleList,averageName, showProgressBar=False, verbose=Fal
 
     if 'gpu' in device:
         from pytom.agnostic.tools import invert_WedgeSum
-        from pytom.agnostic.filter import applyFourierFilter, bandpass
+        from pytom.agnostic.filter import apply_fourier_filter, bandpass
         write(f'{root}-PreWedge{ext}', unweiAv)
         write(f'{root}-WedgeSumUnscaled{ext}', wedgeSum)
         wedgeSum = invert_WedgeSum(invol=wedgeSum, r_max=unweiAv.shape[0] / 2 - 2., lowlimit=.05 * len(particleList),
                         lowval=.05 * len(particleList))
-        unweiAv = applyFourierFilter(unweiAv, wedgeSum)
+        unweiAv = apply_fourier_filter(unweiAv, wedgeSum)
         unweiAv = bandpass(unweiAv, high=unweiAv.shape[0]//2-2, sigma=(unweiAv.shape[0]//2-1)/10.)
         write(averageName, unweiAv)
     else:

--- a/pytom/alignment/GLocalSampling.py
+++ b/pytom/alignment/GLocalSampling.py
@@ -306,7 +306,7 @@ def mainAlignmentLoop(alignmentJob, verbose=False):
             # filter final average according to resolution
             from pytom.basic.filter import lowpassFilter
             filtered_final = lowpassFilter(volume=final_average.getVolume(), band=resolutionBand, smooth=resolutionBand/10,
-                                           fourierOnly=False)[0]
+                                           fourier_only=False)[0]
             filtered_final.write(f"{alignmentJob.destination}/average-FinalFiltered_{resolutionAngstrom:.2f}.{filetype}")
             # clean up temporary files
             from os import remove

--- a/pytom/alignment/GWienerFilterAlignment.py
+++ b/pytom/alignment/GWienerFilterAlignment.py
@@ -621,13 +621,13 @@ class MultiDefocusWorker(FRMWorker):
                 result = vol(size_x,size_y,size_z)
                 result.setAll(0)
                 
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
                 wedgeSum.setAll(0)
             
             # create wedge weighting
             rotation = p.getRotation()
             
-            wedge = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False,rotation.invert())
+            wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False,rotation.invert())
             wedgeSum = wedgeSum + wedge
             
             # shift and rotate particle

--- a/pytom/alignment/GrowingAverage.py
+++ b/pytom/alignment/GrowingAverage.py
@@ -83,7 +83,7 @@ class GAWorker(PyTomClass):
         self._reference = Reference(referenceFile)
         
         wedgeInfo = reference.getWedgeInfo()
-        wedgeVolume = wedgeInfo.returnWedgeVolume(refVolume.size_x(),refVolume.size_y(),refVolume.size_z(),False)
+        wedgeVolume = wedgeInfo.return_wedge_volume(refVolume.size_x(),refVolume.size_y(),refVolume.size_z(),False)
         
         #wedgeVolume.setAll(1);
         wedgeVolume.write(r + '-StartWeight.em')

--- a/pytom/alignment/WienerFilterAlignment.py
+++ b/pytom/alignment/WienerFilterAlignment.py
@@ -549,13 +549,13 @@ class MultiDefocusWorker(FRMWorker):
                 result = vol(size_x,size_y,size_z)
                 result.setAll(0)
                 
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
                 wedgeSum.setAll(0)
             
             # create wedge weighting
             rotation = p.getRotation()
             
-            wedge = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False,rotation.invert())
+            wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False,rotation.invert())
             wedgeSum = wedgeSum + wedge
             
             # shift and rotate particle

--- a/pytom/alignment/alignmentFunctions.py
+++ b/pytom/alignment/alignmentFunctions.py
@@ -346,7 +346,7 @@ def average( particleList, averageName, showProgressBar=False, verbose=False,
     @change: limit for wedgeSum set to 1% or particles to avoid division by small numbers - FF
     """
     from pytom.lib.pytom_volume import read,vol,reducedToFull,limit, complexRealMult
-    from pytom.basic.filter import lowpassFilter, rotateWeighting
+    from pytom.basic.filter import lowpassFilter, rotate_weighting
     from pytom.lib.pytom_volume import transformSpline as transform
     from pytom.basic.fourier import convolute
     from pytom.basic.structures import Reference
@@ -426,7 +426,7 @@ def average( particleList, averageName, showProgressBar=False, verbose=False,
             wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False, rotinvert)
         else:
             # > FF: interpol bugfix
-            wedge = rotateWeighting( weighting=wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False),
+            wedge = rotate_weighting( weighting=wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False),
                                      z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
                                      isReducedComplex=True, returnReducedComplex=True)
             # < FF
@@ -496,7 +496,7 @@ def average2(particleList, weighting=False, norm=False, determine_resolution=Fal
     from pytom.basic.fourier import fft, ifft, convolute
     from pytom.basic.normalise import mean0std1
     from pytom.tools.ProgressBar import FixedProgBar
-    from pytom.basic.filter import lowpassFilter, rotateWeighting
+    from pytom.basic.filter import lowpassFilter, rotate_weighting
     from math import exp
     
     if len(particleList) == 0:
@@ -554,7 +554,7 @@ def average2(particleList, weighting=False, norm=False, determine_resolution=Fal
             # < original buggy version
         else:
             # > FF: interpol bugfix
-            wedge = rotateWeighting( weighting=wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False),
+            wedge = rotate_weighting( weighting=wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False),
                                      z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
                                      isReducedComplex=True, returnReducedComplex=True)
             # < FF
@@ -714,7 +714,7 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
     from pytom.basic.correlation import sub_pixel_peak, sub_pixel_peak_parabolic
     from pytom.alignment.structures import Peak
     from pytom.lib.pytom_volume import peak, vol, vol_comp
-    from pytom.basic.filter import filter,rotateWeighting
+    from pytom.basic.filter import filter,rotate_weighting
     from pytom.basic.structures import Rotation, Shift, Particle, Mask
     from pytom.angles.angle import AngleObject
     from pytom.alignment.preprocessing import Preprocessing
@@ -802,7 +802,7 @@ def bestAlignment(particle, reference, referenceWeighting, wedgeInfo, rotations,
         #weight particle
         if not referenceWeighting.__class__ == str:
             from pytom.lib.pytom_freqweight import weight
-            weightingRotated = rotateWeighting(weighting=referenceWeighting, z1=currentRotation[0],
+            weightingRotated = rotate_weighting(weighting=referenceWeighting, z1=currentRotation[0],
                                                z2=currentRotation[1], x=currentRotation[2], isReducedComplex=True,
                                                returnReducedComplex=True, binarize=False)
             particleCopy.copyVolume(particle)
@@ -985,7 +985,7 @@ def compareTwoVolumes(particle,reference,referenceWeighting,wedgeInfo,rotations,
     """
 
     from pytom.lib.pytom_volume import vol,transformSpline
-    from pytom.basic.filter import filter,rotateWeighting
+    from pytom.basic.filter import filter,rotate_weighting
     from pytom.angles.angleList import OneAngleList
     
     assert particle.__class__ == vol, "particle not of type vol"
@@ -1030,7 +1030,7 @@ def compareTwoVolumes(particle,reference,referenceWeighting,wedgeInfo,rotations,
     if not referenceWeighting.__class__ == str:
         from pytom.lib.pytom_freqweight import weight
         
-        weightingRotated = rotateWeighting(weighting=referenceWeighting, z1=currentRotation[0], z2=currentRotation[1],
+        weightingRotated = rotate_weighting(weighting=referenceWeighting, z1=currentRotation[0], z2=currentRotation[1],
                                            x=currentRotation[2], isReducedComplex=None, returnReducedComplex=True,
                                            binarize=False)
         if verbose:

--- a/pytom/alignment/alignmentFunctions.py
+++ b/pytom/alignment/alignmentFunctions.py
@@ -405,10 +405,10 @@ def average( particleList, averageName, showProgressBar=False, verbose=False,
             result = vol(size_x,size_y,size_z)
             result.setAll(0.0)
             if analytWedge:
-                wedgeSum = wedgeInfo.returnWedgeVolume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z)
             else:
                 # > FF bugfix
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
                 # < FF
                 # > TH bugfix
                 #wedgeSum = vol(size_x,size_y,size_z)
@@ -423,15 +423,15 @@ def average( particleList, averageName, showProgressBar=False, verbose=False,
         rotinvert = rotation.invert()
         if analytWedge:
             # > analytical buggy version
-            wedge = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False, rotinvert)
+            wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False, rotinvert)
         else:
             # > FF: interpol bugfix
-            wedge = rotateWeighting( weighting=wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False),
+            wedge = rotateWeighting( weighting=wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False),
                                      z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
                                      isReducedComplex=True, returnReducedComplex=True)
             # < FF
             # > TH bugfix
-            #wedgeVolume = wedgeInfo.returnWedgeVolume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z,
+            #wedgeVolume = wedgeInfo.return_wedge_volume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z,
             #                                    humanUnderstandable=True, rotation=rotinvert)
             #wedge = rotate(volume=wedgeVolume, rotation=rotinvert, imethod='linear')
             # < TH
@@ -539,9 +539,9 @@ def average2(particleList, weighting=False, norm=False, determine_resolution=Fal
             even = vol(size_x,size_y,size_z)
             even.setAll(0.0)
             
-            wedgeSum_odd = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+            wedgeSum_odd = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
             wedgeSum_odd.setAll(0)
-            wedgeSum_even = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+            wedgeSum_even = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
             wedgeSum_even.setAll(0)
         
 
@@ -550,16 +550,16 @@ def average2(particleList, weighting=False, norm=False, determine_resolution=Fal
         rotinvert =  rotation.invert()
         if analytWedge:
             # > original buggy version
-            wedge = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False, rotinvert)
+            wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False, rotinvert)
             # < original buggy version
         else:
             # > FF: interpol bugfix
-            wedge = rotateWeighting( weighting=wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False),
+            wedge = rotateWeighting( weighting=wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False),
                                      z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
                                      isReducedComplex=True, returnReducedComplex=True)
             # < FF
             # > TH bugfix
-            #wedgeVolume = wedgeInfo.returnWedgeVolume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z,
+            #wedgeVolume = wedgeInfo.return_wedge_volume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z,
             #                                          humanUnderstandable=True, rotation=rotinvert)
             #wedge = rotate(volume=wedgeVolume, rotation=rotinvert, imethod='linear')
             # < TH

--- a/pytom/basic/convert.py
+++ b/pytom/basic/convert.py
@@ -70,13 +70,13 @@ def readSubvolumeFromFourierspaceFile(filename,size_x,size_y,size_z):
     Works only if fourier file is reduced complex without any shift applied.      
     @param filename: The fourier space file name
     @param size_x: X final size of subvolume if it was complete 
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume} with 
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume} with 
     humanUnderstandable == True returns)
     @param size_y: Y final size of subvolume if it was complete 
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume} 
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume} 
     with humanUnderstandable == True returns)
     @param size_z: Z final size of subvolume if it was complete 
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume} 
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume} 
     with humanUnderstandable == True returns)
     @return: A subvolume 
     @author: Thomas Hrabe

--- a/pytom/basic/correlation.py
+++ b/pytom/basic/correlation.py
@@ -388,8 +388,8 @@ def band_cc(volume,reference,band,verbose = False):
     if verbose:
         print('lowest freq : ', band[0],' highest freq' , band[1])
         
-    vf = bandpassFilter(volume,band[0],band[1],fourierOnly=True)
-    rf = bandpassFilter(reference,band[0],band[1],vf[1],fourierOnly=True)
+    vf = bandpassFilter(volume,band[0],band[1],fourier_only=True)
+    rf = bandpassFilter(reference,band[0],band[1],vf[1],fourier_only=True)
     
     ccVolume = pytom_volume.vol_comp(rf[0].size_x(),rf[0].size_y(),rf[0].size_z())
     ccVolume.copyVolume(rf[0])
@@ -572,8 +572,8 @@ def band_cf(volume,reference,band=[0,100]):
     from pytom.basic.filter import bandpassFilter
     from pytom.basic.correlation import norm_xcf
     
-    vf = bandpassFilter(volume,band[0],band[1],fourierOnly=True)
-    rf = bandpassFilter(reference,band[0],band[1],vf[1],fourierOnly=True)
+    vf = bandpassFilter(volume,band[0],band[1],fourier_only=True)
+    rf = bandpassFilter(reference,band[0],band[1],vf[1],fourier_only=True)
     
     v = pytom_volume.reducedToFull(vf[0])
     r = pytom_volume.reducedToFull(rf[0])

--- a/pytom/basic/correlation.py
+++ b/pytom/basic/correlation.py
@@ -459,7 +459,7 @@ def weighted_xcc(volume,reference,number_of_bands,wedge_angle=-1):
         freference.shiftscale(0,1/float(numelem))
         from pytom.basic.structures import WedgeInfo
         wedge = WedgeInfo(wedge_angle)
-        wedgeVolume = wedge.returnWedgeVolume(volume.size_x(),volume.size_y(),volume.size_z())
+        wedgeVolume = wedge.return_wedge_volume(volume.size_x(),volume.size_y(),volume.size_z())
         
         increment = int(volume.size_x()/2 * 1/number_of_bands)
         band = [0,100]

--- a/pytom/basic/files.py
+++ b/pytom/basic/files.py
@@ -79,13 +79,13 @@ def readSubvolumeFromFourierspaceFile(filename, size_x, size_y, size_z):
     Works only if fourier file is reduced complex without any shift applied.
     @param filename: The fourier space file name
     @param size_x: X final size of subvolume if it was complete
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume} with
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume} with
     humanUnderstandable == True returns)
     @param size_y: Y final size of subvolume if it was complete
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume}
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume}
     with humanUnderstandable == True returns)
     @param size_z: Z final size of subvolume if it was complete
-    (what L{pytom.basic.structures.Wedge.returnWedgeVolume}
+    (what L{pytom.basic.structures.Wedge.return_wedge_volume}
     with humanUnderstandable == True returns)
     @return: A subvolume
     @author: Thomas Hrabe

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -513,7 +513,7 @@ def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, retu
     
     return returnVolume
     
-def wedgeFilter(volume,angle,radius=0,angleIsHalf=True,fourierOnly=False):
+def wedgeFilter(volume,angle,radius=0,angleIsHalf=True,fourier_only=False):
     """
     wedgeFilter: performs a single wedge filtering of volume.
     @param volume: The volume filtered.
@@ -537,9 +537,9 @@ def wedgeFilter(volume,angle,radius=0,angleIsHalf=True,fourierOnly=False):
     wf = pytom_freqweight.weight(angle,radius,volume.size_x(),volume.size_y(),volume.size_z())
     
     
-    return filter(volume,wf,fourierOnly)
+    return filter(volume,wf,fourier_only)
 
-def bandpassFilter(volume, lowestFrequency, highestFrequency, bpf=None, smooth=0,fourierOnly=False):
+def bandpassFilter(volume, lowestFrequency, highestFrequency, bpf=None, smooth=0,fourier_only=False):
     """
     bandpassFilter: Performs bandpass filtering of volume.
     @param volume: The volume to be filtered
@@ -567,9 +567,9 @@ def bandpassFilter(volume, lowestFrequency, highestFrequency, bpf=None, smooth=0
         bpf = pytom_freqweight.weight(lowestFrequency,highestFrequency,
                                       fvolume.size_x(),fvolume.size_y(),fvolume.size_z(),smooth)    
 
-    return filter(fvolume,bpf,fourierOnly)      
+    return filter(fvolume,bpf,fourier_only)      
 
-def lowpassFilter(volume,band,smooth=0,fourierOnly=False):
+def lowpassFilter(volume,band,smooth=0,fourier_only=False):
     """
     lowpassFilter: 
     @param volume: The volume filtered
@@ -591,9 +591,9 @@ def lowpassFilter(volume,band,smooth=0,fourierOnly=False):
         
     lpf = pytom_freqweight.weight(0.0,band,fvolume.size_x(),fvolume.size_y(),fvolume.size_z(),smooth)
     
-    return filter(fvolume,lpf,fourierOnly)
+    return filter(fvolume,lpf,fourier_only)
     
-def highpassFilter(volume,band,smooth=0,fourierOnly=False):   
+def highpassFilter(volume,band,smooth=0,fourier_only=False):   
     """
     highpassFilter:
     @param volume:  The volume filtered
@@ -614,9 +614,9 @@ def highpassFilter(volume,band,smooth=0,fourierOnly=False):
     
     hpf = pytom_freqweight.weight(band,fvolume.size_x(),fvolume.size_x(),fvolume.size_y(),fvolume.size_z(),smooth)
        
-    return filter(fvolume,hpf,fourierOnly)
+    return filter(fvolume,hpf,fourier_only)
 
-def filter(volume,filterObject,fourierOnly=False):
+def filter(volume,filterObject,fourier_only=False):
     """
     filter: A generic filter method.
     @param volume: The volume to be filtered
@@ -643,7 +643,7 @@ def filter(volume,filterObject,fourierOnly=False):
             noPixels = volume.size_x() * volume.size_y() * 2*(volume.size_z()-1)
     filterObject.apply(fvolume)
     
-    if not fourierOnly:
+    if not fourier_only:
         result = ifft(fvolume)/noPixels
         return [result,filterObject,fvolume]   
     else:

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -360,7 +360,7 @@ def rampFilter( size_x, size_y, crowther_freq=None, N=None):
 
     return filter_vol
 
-def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
+def exactFilter(tilt_angles, tilt_angle, sX, sY, slice_width, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
@@ -376,7 +376,7 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
     sY = sY//2+1
 
     # Calculate the relative angles in radians.
-    sampling = np.sin(np.abs((np.array(tilt_angles) - tiltAngle) * np.pi / 180.))
+    sampling = np.sin(np.abs((np.array(tilt_angles) - tilt_angle) * np.pi / 180.))
     smallest_sampling = np.min(sampling[sampling > 0.001])
 
     if slice_width / smallest_sampling > sX // 2:  # crowther crit can be to nyquist freq (i.e. sX // 2)
@@ -404,7 +404,7 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
         
     return weightFunc
 
-def rotateFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
+def rotateFilter(tilt_angles, tilt_angle, sX, sY, slice_width, arr=[]):
     """
     rotate filter function
     @param tilt_angles: ...
@@ -418,7 +418,7 @@ def rotateFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
 
     tilt_angles = array(tilt_angles)
 
-    smallest = abs(tilt_angles - tiltAngle)
+    smallest = abs(tilt_angles - tilt_angle)
     smallest[smallest.argmin()] = 1000
     smallest = smallest.min()
 
@@ -434,7 +434,7 @@ def rotateFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
 
     out = zeros_like(a)
 
-    for angle in (tilt_angles - tiltAngle):
+    for angle in (tilt_angles - tilt_angle):
 
         if abs(angle) > 0.0001:
             dame2 = rotate(dame, angle, axes=(0, 1), reshape=False)

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -296,12 +296,12 @@ def fourierFilterShift_ReducedComplex(filter):
 
     return shifted_filter
 
-def circleFilter(size_x,size_y, radiusCutoff):
+def circleFilter(size_x,size_y, cutoff_radius):
     """
     circleFilter: NEEDS Documentation
     @param size_x: NEEDS Documentation 
     @param size_y: NEEDS Documentation
-    @param radiusCutoff: NEEDS Documentation
+    @param cutoff_radius: NEEDS Documentation
     """
     from pytom.lib.pytom_volume import vol
     
@@ -318,7 +318,7 @@ def circleFilter(size_x,size_y, radiusCutoff):
                         
             radius = ((i-centerX)*(i-centerX)+(j-centerY)*(j-centerY))**0.5
                                                 
-            if radius <= radiusCutoff:
+            if radius <= cutoff_radius:
                 filter_vol.setV(1.0, i, j, 0)
                 
     return filter_vol

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -4,7 +4,7 @@ from pytom.lib.pytom_volume import reducedToFull, fullToReduced, vol, max
 from math import sqrt
 
 
-def profile2FourierVol( profile, dim=None, reduced=False):
+def profile_to_fourier_vol( profile, dim=None, reduced=False):
     """
     create Volume from 1d radial profile, e.g., to modulate signal with \
     specific function such as CTF or FSC. Simple linear interpolation is used\
@@ -93,10 +93,10 @@ def filter_volume_by_profile( volume, profile):
     @rtype: L{pytom.lib.pytom_volume.vol}
     @author: FF
     """
-    from pytom.basic.filter import profile2FourierVol
+    from pytom.basic.filter import profile_to_fourier_vol
     from pytom.basic.fourier import convolute, powerspectrum
 
-    kernel = profile2FourierVol( profile=profile, dim=volume.size_x(), reduced=False)
+    kernel = profile_to_fourier_vol( profile=profile, dim=volume.size_x(), reduced=False)
     outvol = convolute(v=volume, k=kernel, kernel_in_fourier=True)
     return outvol
 
@@ -708,8 +708,8 @@ def wiener_filter(fsc, even_ctf_sum, odd_ctf_sum, fudge=1):
     fsc[rmax:] = 0  # set to 0 after first crossing to prevent artifacts
 
     # turn radial average profile and fsc profile into volumes
-    fsc_vol = profile2FourierVol(fsc, dim=sx)
-    radial_vol = profile2FourierVol(radial, dim=sx)
+    fsc_vol = profile_to_fourier_vol(fsc, dim=sx)
+    radial_vol = profile_to_fourier_vol(radial, dim=sx)
 
     even_filter = vol(sx, sy, sz)
     even_filter.setAll(0.)

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -360,7 +360,7 @@ def rampFilter( size_x, size_y, crowther_freq=None, N=None):
 
     return filter_vol
 
-def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
+def exactFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
     """
     exactFilter: Generates the exact weighting function required for weighted backprojection - y-axis is tilt axis
     Reference : Optik, Exact filters for general geometry three dimensional reconstuction, vol.73,146,1986.
@@ -379,15 +379,15 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     sampling = np.sin(np.abs((np.array(tilt_angles) - tiltAngle) * np.pi / 180.))
     smallest_sampling = np.min(sampling[sampling > 0.001])
 
-    if sliceWidth / smallest_sampling > sX // 2:  # crowther crit can be to nyquist freq (i.e. sX // 2)
-        sliceWidth = smallest_sampling * (sX // 2)  # adjust sliceWidth if too large
+    if slice_width / smallest_sampling > sX // 2:  # crowther crit can be to nyquist freq (i.e. sX // 2)
+        slice_width = smallest_sampling * (sX // 2)  # adjust slice_width if too large
 
-    crowther_freq = min(sX // 2, int(np.ceil(sliceWidth / smallest_sampling)))
+    crowther_freq = min(sX // 2, int(np.ceil(slice_width / smallest_sampling)))
     arrCrowther = np.abs(np.arange(-crowther_freq, min(sX // 2, crowther_freq + 1)))
 
     # as in the paper: 1 - frequency / overlap_frequency
-    # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/sliceWidth
-    wfuncCrowther = 1. / np.clip(1 - ((sampling / sliceWidth)[:, np.newaxis] * arrCrowther) ** 2, 0, 2).sum(axis=0)
+    # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/slice_width
+    wfuncCrowther = 1. / np.clip(1 - ((sampling / slice_width)[:, np.newaxis] * arrCrowther) ** 2, 0, 2).sum(axis=0)
 
     # Create full with weightFunc
     wfunc = np.ones((sX, sY, 1), dtype=float)
@@ -404,7 +404,7 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
         
     return weightFunc
 
-def rotateFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
+def rotateFilter(tilt_angles, tiltAngle, sX, sY, slice_width, arr=[]):
     """
     rotate filter function
     @param tilt_angles: ...

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -323,7 +323,7 @@ def circleFilter(size_x,size_y, cutoff_radius):
                 
     return filter_vol
 
-def rampFilter( size_x, size_y, crowtherFreq=None, N=None):
+def rampFilter( size_x, size_y, crowther_freq=None, N=None):
     """
     rampFilter: Generates the weighting function required for weighted backprojection - y-axis is tilt axis
 
@@ -343,10 +343,10 @@ def rampFilter( size_x, size_y, crowtherFreq=None, N=None):
 
     N = 0 if N is None else 1 / N
 
-    if crowtherFreq is None:
+    if crowther_freq is None:
         Ny = size_x//2
     else:
-        Ny = crowtherFreq
+        Ny = crowther_freq
 
     filter_vol = vol(size_x, size_y, 1)
     filter_vol.setAll(0.0)
@@ -382,8 +382,8 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
     if sliceWidth / smallest_sampling > sX // 2:  # crowther crit can be to nyquist freq (i.e. sX // 2)
         sliceWidth = smallest_sampling * (sX // 2)  # adjust sliceWidth if too large
 
-    crowtherFreq = min(sX // 2, int(np.ceil(sliceWidth / smallest_sampling)))
-    arrCrowther = np.abs(np.arange(-crowtherFreq, min(sX // 2, crowtherFreq + 1)))
+    crowther_freq = min(sX // 2, int(np.ceil(sliceWidth / smallest_sampling)))
+    arrCrowther = np.abs(np.arange(-crowther_freq, min(sX // 2, crowther_freq + 1)))
 
     # as in the paper: 1 - frequency / overlap_frequency
     # where frequency = arrCrowther, and 1 / overlap_frequency = sampling/sliceWidth
@@ -391,7 +391,7 @@ def exactFilter(tilt_angles, tiltAngle, sX, sY, sliceWidth, arr=[]):
 
     # Create full with weightFunc
     wfunc = np.ones((sX, sY, 1), dtype=float)
-    wfunc[sX//2-crowtherFreq:sX//2+min(sX//2,crowtherFreq+1),:, 0] = np.tile(wfuncCrowther, (sY, 1)).T
+    wfunc[sX//2-crowther_freq:sX//2+min(sX//2,crowther_freq+1),:, 0] = np.tile(wfuncCrowther, (sY, 1)).T
 
     weightFunc = vol(sX, sY, 1)
     weightFunc.setAll(0.0)

--- a/pytom/basic/filter.py
+++ b/pytom/basic/filter.py
@@ -456,9 +456,9 @@ def rotateFilter(tilt_angles, tilt_angle, sX, sY, slice_width, arr=[]):
 
     return weightFunc
 
-def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, returnReducedComplex=False, binarize=False):
+def rotate_weighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, returnReducedComplex=False, binarize=False):
     """
-    rotateWeighting: Rotates a frequency weighting volume around the center. If the volume provided is reduced complex, it will be rescaled to full size, ftshifted, rotated, iftshifted and scaled back to reduced size.
+    rotate_weighting: Rotates a frequency weighting volume around the center. If the volume provided is reduced complex, it will be rescaled to full size, ftshifted, rotated, iftshifted and scaled back to reduced size.
     @param weighting: A weighting volume
     @type weighting: L{pytom.lib.pytom_volume.vol}
     @param z1: Z1 rotation angle
@@ -480,7 +480,7 @@ def rotateWeighting(weighting, z1, z2, x, mask=None, isReducedComplex=None, retu
     @rtype: L{pytom.lib.pytom_volume.vol_comp}
     """
     from pytom.lib.pytom_volume import vol, limit, vol_comp, rotate
-    assert type(weighting) == vol or  type(weighting) == vol_comp, "rotateWeighting: input neither vol nor vol_comp"
+    assert type(weighting) == vol or  type(weighting) == vol_comp, "rotate_weighting: input neither vol nor vol_comp"
     
     isReducedComplex = isReducedComplex or int(weighting.size_x()/2)+1 == weighting.size_z();
 

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -563,12 +563,12 @@ class Reference(PyTomClass):
         rotinvert =  particleRotation.invert()
         if analytWedge:
             # > buggy version
-            wedge = particleWedge.returnWedgeVolume(particleTransformed.size_x(),particleTransformed.size_y(),
+            wedge = particleWedge.return_wedge_volume(particleTransformed.size_x(),particleTransformed.size_y(),
                                                     particleTransformed.size_z(),False,rotinvert)
             # < buggy version
         else:
             # > FF bugfix
-            wedge = rotateWeighting( weighting=particleWedge.returnWedgeVolume(particleTransformed.size_x(),
+            wedge = rotateWeighting( weighting=particleWedge.return_wedge_volume(particleTransformed.size_x(),
                                                                                particleTransformed.size_y(),
                                                                                particleTransformed.size_z(),False),
                                  z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
@@ -847,9 +847,9 @@ class Wedge(PyTomClass):
         else:
             return self._wedgeObject.returnWedgeFilter(wedgeSizeX,wedgeSizeY,wedgeSizeZ,rotation)
     
-    def returnWedgeVolume(self,wedgeSizeX=None,wedgeSizeY=None,wedgeSizeZ=None,humanUnderstandable=False,rotation=None):
+    def return_wedge_volume(self,wedgeSizeX=None,wedgeSizeY=None,wedgeSizeZ=None,humanUnderstandable=False,rotation=None):
         """
-        returnWedgeVolume: Returns a wedge volume for later processing. 
+        return_wedge_volume: Returns a wedge volume for later processing. 
         @param wedgeSizeX: volume size for x (size of original volume in real space) 
         @param wedgeSizeY: volume size for y (size of original volume in real space)
         @param wedgeSizeZ: volume size for z (size of original volume in real space)
@@ -860,7 +860,7 @@ class Wedge(PyTomClass):
         @author: Thomas Hrabe 
         """
         
-        return self._wedgeObject.returnWedgeVolume(wedgeSizeX,wedgeSizeY,wedgeSizeZ,humanUnderstandable,rotation)
+        return self._wedgeObject.return_wedge_volume(wedgeSizeX,wedgeSizeY,wedgeSizeZ,humanUnderstandable,rotation)
     
     def getWedgeAngle(self):
         """
@@ -1101,10 +1101,10 @@ class SingleTiltWedge(PyTomClass):
                 
         return weightObject
     
-    def returnWedgeVolume(self,wedgeSizeX,wedgeSizeY,wedgeSizeZ,humanUnderstandable=False, rotation=None,
+    def return_wedge_volume(self,wedgeSizeX,wedgeSizeY,wedgeSizeZ,humanUnderstandable=False, rotation=None,
                           as_numpy=False):
         """
-        returnWedgeVolume: Returns a wedge volume for later processing. 
+        return_wedge_volume: Returns a wedge volume for later processing. 
         @param wedgeSizeX: volume size for x (size of original volume in real space) 
         @param wedgeSizeY: volume size for y (size of original volume in real space)
         @param wedgeSizeZ: volume size for z (size of original volume in real space)
@@ -1186,7 +1186,7 @@ class SingleTiltWedge(PyTomClass):
         assert (b <= 128)
         # r = 45  # this radius and the volume size should be sufficient for sampling b <= 128
         if self._wedge_vol is None:
-            self._wedge_vol = self.returnWedgeVolume(100, 100, 100, humanUnderstandable=True, as_numpy=True)
+            self._wedge_vol = self.return_wedge_volume(100, 100, 100, humanUnderstandable=True, as_numpy=True)
 
         size_x, size_y, size_z = self._wedge_vol.shape
 
@@ -1350,10 +1350,10 @@ be generated. If omitted / 0, filter is fixed to size/2.
         self._bw = None
         self._sf = None
         
-    def returnWedgeVolume(self, wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable=False, rotation=None,
+    def return_wedge_volume(self, wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable=False, rotation=None,
                           as_numpy=False):
         """
-        returnWedgeVolume: Returns a wedge volume for later processing. 
+        return_wedge_volume: Returns a wedge volume for later processing. 
         @param wedgeSizeX: volume size for x (size of original volume in real space) 
         @param wedgeSizeY: volume size for y (size of original volume in real space)
         @param wedgeSizeZ: volume size for z (size of original volume in real space)
@@ -1366,8 +1366,8 @@ be generated. If omitted / 0, filter is fixed to size/2.
         """
         from pytom.lib.pytom_volume import vol, limit
         
-        w1 = self._wedge1.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
-        w2 = self._wedge2.returnWedgeVolume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
+        w1 = self._wedge1.return_wedge_volume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
+        w2 = self._wedge2.return_wedge_volume(wedgeSizeX, wedgeSizeY, wedgeSizeZ, humanUnderstandable, rotation)
         
         # combine into one
         w = w1+w2
@@ -1390,7 +1390,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
         assert (b <= 128)
         # r = 45  # this radius and the volume size should be sufficient for sampling b <= 128
         if self._wedge_vol is None:
-            self._wedge_vol = self.returnWedgeVolume(100, 100, 100, humanUnderstandable=True, as_numpy=True)
+            self._wedge_vol = self.return_wedge_volume(100, 100, 100, humanUnderstandable=True, as_numpy=True)
 
         size_x, size_y, size_z = self._wedge_vol.shape
 
@@ -1471,7 +1471,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
         if not volume.__class__ == vol:
             raise TypeError('You must provide a pytom.lib.pytom_volume.vol here!')
     
-        wedgeVolume = self.returnWedgeVolume(volume.size_x(),volume.size_y(),volume.size_z(),
+        wedgeVolume = self.return_wedge_volume(volume.size_x(),volume.size_y(),volume.size_z(),
                            humanUnderstandable = False,rotation=rotation)
         fvolume     = fft(volume) 
         fresult     = complexRealMult(fvolume, wedgeVolume)
@@ -1514,7 +1514,7 @@ class Wedge3dCTF(PyTomClass):
     def set_ctf_max_resolution(self, ctf_max_resolution):
         self._ctf_max_resolution = ctf_max_resolution
 
-    def returnWedgeVolume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
+    def return_wedge_volume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False,
                           rotation=None, as_numpy=False):
         """parameters here are not needed but for compat with the wedge class"""
         if wedgeSizeX is not None or wedgeSizeY is not None or wedgeSizeZ is not None:
@@ -1536,7 +1536,7 @@ class Wedge3dCTF(PyTomClass):
         if not volume.__class__ == vol:
             raise TypeError('Wedge3dCTF: You must provide a pytom.lib.pytom_volume.vol here!')
 
-        wedge = self.returnWedgeVolume(rotation=rotation)
+        wedge = self.return_wedge_volume(rotation=rotation)
 
         return convolute(volume, wedge, kernel_in_fourier=True)
 
@@ -1550,7 +1550,7 @@ class Wedge3dCTF(PyTomClass):
         assert (b <= 128)
         # r = 45  # this radius and the volume size should be sufficient for sampling b <= 128
         if self._wedge_vol is None:
-            self._wedge_vol = self.returnWedgeVolume(humanUnderstandable=True, as_numpy=True)
+            self._wedge_vol = self.return_wedge_volume(humanUnderstandable=True, as_numpy=True)
 
         size_x, size_y, size_z = self._wedge_vol.shape
 
@@ -1653,7 +1653,7 @@ class GeneralWedge(PyTomClass):
          
         return w
     
-    def returnWedgeVolume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False, rotation=None):
+    def return_wedge_volume(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, humanUnderstandable=False, rotation=None):
         wedgeFilter = self.returnWedgeFilter(None, None, None, rotation)
         
         # return only the reduced complex part
@@ -3310,9 +3310,9 @@ class ParticleList(PyTomClass):
             # rotate the wedge
             w = p.getWedge()
             if sum_w is None:
-                sum_w = w.returnWedgeVolume(v.size_x(),v.size_y(),v.size_z(), False, p.getRotation().invert())
+                sum_w = w.return_wedge_volume(v.size_x(),v.size_y(),v.size_z(), False, p.getRotation().invert())
             else:
-                sum_w += w.returnWedgeVolume(v.size_x(),v.size_y(),v.size_z(), False, p.getRotation().invert())
+                sum_w += w.return_wedge_volume(v.size_x(),v.size_y(),v.size_z(), False, p.getRotation().invert())
             
             # calculate the variance
             wa = w.apply(average, p.getRotation().invert())

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -806,7 +806,7 @@ class Wedge(PyTomClass):
     """
     Wedge: used as an dummy class to distinguish between single tilt axis wedge and double tilt axis wedge in fromXML
     """
-    def __init__(self, wedge_angles=[0.0,0.0], cutoffRadius=0.0, tiltAxis='Y', smooth=0.0, wedge_3d_ctf_file='',
+    def __init__(self, wedge_angles=[0.0,0.0], cutoff_radius=0.0, tiltAxis='Y', smooth=0.0, wedge_3d_ctf_file='',
                  ctf_max_resolution=0.):
         """
         __init__: This constructor is compatible to L{pytom.basic.structures.SingleTiltWedge} and L{pytom.basic.structures.DoubleTiltWedge}.
@@ -820,7 +820,7 @@ class Wedge(PyTomClass):
             try:
 
                 if wedge_angles.__class__ == list and wedge_angles[0].__class__ == list and len(wedge_angles[0]) == 2 and wedge_angles[1].__class__ == list and len(wedge_angles[1]) == 2:
-                    self._wedgeObject = DoubleTiltWedge(wedge_angles=wedge_angles, tiltAxis1='Y', rotation12=tiltAxis, cutoffRadius=cutoffRadius, smooth = smooth)
+                    self._wedgeObject = DoubleTiltWedge(wedge_angles=wedge_angles, tiltAxis1='Y', rotation12=tiltAxis, cutoff_radius=cutoff_radius, smooth = smooth)
                     self._type = 'DoubleTiltWedge'
                 else:
 
@@ -828,7 +828,7 @@ class Wedge(PyTomClass):
             except :
                 if wedge_angles.__class__ == list and wedge_angles[0].__class__ == list and wedge_angles[1].__class__ == list:
                     raise TypeError('Wrong parameters for SingleTiltWedge object error thrown by Wedge object!')
-                self._wedgeObject = SingleTiltWedge(wedge_angles,cutoffRadius=cutoffRadius,tiltAxis=tiltAxis,smooth=smooth)
+                self._wedgeObject = SingleTiltWedge(wedge_angles,cutoff_radius=cutoff_radius,tiltAxis=tiltAxis,smooth=smooth)
                 self._type = 'SingleTiltWedge'
         
     def returnWedgeFilter(self, wedgeSizeX=None, wedgeSizeY=None, wedgeSizeZ=None, rotation=None):
@@ -976,7 +976,7 @@ class Wedge(PyTomClass):
             else:
                 w1, w2 = angle
 
-            cutoff = self._wedgeObject._cutoffRadius
+            cutoff = self._wedgeObject._cutoff_radius
             smooth = self._wedgeObject._smooth
             wedge = Wedge([w1, w2], cutoff, smooth=smooth)
             return wedge
@@ -1000,14 +1000,14 @@ class SingleTiltWedge(PyTomClass):
     rotation. Supports asymmetric wedges.
     @author: Thomas Hrabe
     """
-    def __init__(self, wedge_angle=0.0, rotation=None, cutoffRadius=0.0, tiltAxis='Y', smooth=0.0):
+    def __init__(self, wedge_angle=0.0, rotation=None, cutoff_radius=0.0, tiltAxis='Y', smooth=0.0):
         """
         @param wedge_angle: The wedge angle. In wedge halfs. 
         @type wedge_angle: either float (for symmetric wedge) or [float,float]  for \
             asymmetric wedge.
         @param rotation: deprecated!!! Only leave it here for compatibility reason.
         @deprecated: rotation
-        @param cutoffRadius: Maximum frequency (in pixels) up to where wedge will \
+        @param cutoff_radius: Maximum frequency (in pixels) up to where wedge will \
             be generated. If omitted / 0, filter is fixed to size/2.
         @param tiltAxis: Default will be Y. You can choose between the strings "X",\
             "Y" or "custom". You can also specify a Rotation object
@@ -1026,7 +1026,7 @@ class SingleTiltWedge(PyTomClass):
 
         if rotation:
             pass#print("average: Warning - input rotation will not be used because deprecated!")
-        self._cutoffRadius = cutoffRadius
+        self._cutoff_radius = cutoff_radius
         self._tiltAxisRotation = Rotation(0.0,0.0,0.0)
         
         if tiltAxis.__class__ == str:
@@ -1087,10 +1087,10 @@ class SingleTiltWedge(PyTomClass):
         """
         from pytom.lib.pytom_freqweight import weight
         from pytom.basic.structures import Rotation
-        if self._cutoffRadius  == 0.0:
+        if self._cutoff_radius  == 0.0:
             cut = wedgeSizeX//2
         else:
-            cut = self._cutoffRadius
+            cut = self._cutoff_radius
         weightObject = weight(self._wedge_angle1,self._wedge_angle2, cut, wedgeSizeX, wedgeSizeY, wedgeSizeZ, float(self._smooth))
 
         if not rotation.__class__ == Rotation:
@@ -1238,7 +1238,7 @@ class SingleTiltWedge(PyTomClass):
             self._wedge_angle1 = float(xmlObj.get('Angle1'))
             self._wedge_angle2 = float(xmlObj.get('Angle2'))
         
-        self._cutoffRadius = float(xmlObj.get('CutoffRadius'))
+        self._cutoff_radius = float(xmlObj.get('CutoffRadius'))
         
         if(xmlObj.get('Smooth')!=None):
             self._smooth = float(xmlObj.get('Smooth'))
@@ -1263,7 +1263,7 @@ class SingleTiltWedge(PyTomClass):
         from lxml import etree
     
         wedgeElement = etree.Element('SingleTiltWedge',Angle1 = str(self._wedge_angle1), 
-	    Angle2 = str(self._wedge_angle2), CutoffRadius = str(self._cutoffRadius), 
+	    Angle2 = str(self._wedge_angle2), CutoffRadius = str(self._cutoff_radius), 
 	    Smooth = str(self._smooth))
         
         if((not isinstance(self._tiltAxisRotation, int)) or 
@@ -1295,7 +1295,7 @@ class DoubleTiltWedge(SingleTiltWedge):
     """
     DoubleTiltWedge: Represents a wedge determined for a double tilt series of projections 
     """
-    def __init__(self, wedge_angles=[[0,0],[0,0]], tiltAxis1='Y', rotation12=[90,0,0], cutoffRadius=0.0, smooth = 0.0):
+    def __init__(self, wedge_angles=[[0,0],[0,0]], tiltAxis1='Y', rotation12=[90,0,0], cutoff_radius=0.0, smooth = 0.0):
         """Initialize a double tilt wedge
         @param wedge_angles: List of the tilt parameters [[tilt1.1,tilt1.2],[tilt2.1,tilt2.2]]. \
 The missing region. All should be positive degrees.
@@ -1306,7 +1306,7 @@ be set to X -> the double tilt wedge is perfectly rotated by 90 degrees.
 L{pytom.basic.structures.Rotation}
         @param rotation12: Rotation of 2nd tilt series with respect to 1st
         @type rotation12: rotation object L{pytom.basic.structures.Rotation} or 3-dim list
-        @param cutoffRadius: Maximum frequency (in pixels) up to where wedge will \
+        @param cutoff_radius: Maximum frequency (in pixels) up to where wedge will \
 be generated. If omitted / 0, filter is fixed to size/2.
         @param smooth: Smoothing size of wedge at the edges in degrees. Default is 0.  
         """
@@ -1342,8 +1342,8 @@ be generated. If omitted / 0, filter is fixed to size/2.
 
         tiltAxis2 = (rotation12 * tiltAxis1)
         
-        self._wedge1 = SingleTiltWedge(tilt1,None,cutoffRadius,tiltAxis=tiltAxis1,smooth=smooth)
-        self._wedge2 = SingleTiltWedge(tilt2,None,cutoffRadius,tiltAxis=tiltAxis2,smooth=smooth)
+        self._wedge1 = SingleTiltWedge(tilt1,None,cutoff_radius,tiltAxis=tiltAxis1,smooth=smooth)
+        self._wedge2 = SingleTiltWedge(tilt2,None,cutoff_radius,tiltAxis=tiltAxis2,smooth=smooth)
         
         # for FRM
         self._wedge_vol = None # cache for storing the wedge volume

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -4920,6 +4920,6 @@ class BandPassFilter(PyTomClass):
         if volume.size_x()/2 < self._highestFrequency or volume.size_y()/2 < self._highestFrequency or volume.size_z()/2 < self._highestFrequency:
             print("Warning: Highest frequency in bandpass is larger than volume size.")
         
-        res = bandpassFilter(volume,self._lowestFrequency,self._highestFrequency,bpf=None,smooth=self._smooth,fourierOnly=False)
+        res = bandpassFilter(volume,self._lowestFrequency,self._highestFrequency,bpf=None,smooth=self._smooth,fourier_only=False)
         return res[0]
 

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -9,7 +9,7 @@ import numpy as np
 from math import pi, sin, cos
 from scipy.ndimage.interpolation import map_coordinates
 from pytom.basic.files import read
-from pytom.basic.filter import rotateWeighting
+from pytom.basic.filter import rotate_weighting
 from pytom.lib.pytom_volume import reducedToFull, vol
 from pytom.lib.pytom_numpy import vol2npy
 from pytom.basic.fourier import convolute, ftshift
@@ -540,7 +540,7 @@ class Reference(PyTomClass):
 
         from pytom.lib.pytom_volume import read
         from pytom.basic.fourier import convolute
-        from pytom.basic.filter import rotateWeighting
+        from pytom.basic.filter import rotate_weighting
         from pytom.alignment.alignmentFunctions import invert_WedgeSum
         from pytom.basic.filter import filter_volume_by_profile
         from pytom.basic.resolution import read_fscFromAscii
@@ -568,7 +568,7 @@ class Reference(PyTomClass):
             # < buggy version
         else:
             # > FF bugfix
-            wedge = rotateWeighting( weighting=particleWedge.return_wedge_volume(particleTransformed.size_x(),
+            wedge = rotate_weighting( weighting=particleWedge.return_wedge_volume(particleTransformed.size_x(),
                                                                                particleTransformed.size_y(),
                                                                                particleTransformed.size_z(),False),
                                  z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
@@ -1521,7 +1521,7 @@ class Wedge3dCTF(PyTomClass):
             print('WARNING! Wedge size specification wont have effect for 3d ctf wedge!')
         wedge = read(self._filename)
         if rotation is not None:
-            wedge = rotateWeighting(wedge, z1=rotation[0], z2=rotation[1], x=rotation[2], mask=None,
+            wedge = rotate_weighting(wedge, z1=rotation[0], z2=rotation[1], x=rotation[2], mask=None,
                                     isReducedComplex=True, returnReducedComplex=True)
         if humanUnderstandable:
             wedge = ftshift(reducedToFull(wedge), False)

--- a/pytom/basic/structures.py
+++ b/pytom/basic/structures.py
@@ -893,13 +893,13 @@ class Wedge(PyTomClass):
         """
         return self._wedgeObject
     
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
         @return: a spherical function in numpy.array
         """
-        return self._wedgeObject.toSphericalFunc(b, radius)
+        return self._wedgeObject.to_spherical_func(b, radius)
     
     def toXML(self):
         
@@ -1176,7 +1176,7 @@ class SingleTiltWedge(PyTomClass):
         else:
             return volume
     
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
@@ -1380,7 +1380,7 @@ be generated. If omitted / 0, filter is fixed to size/2.
         else:
             return w
     
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
@@ -1540,7 +1540,7 @@ class Wedge3dCTF(PyTomClass):
 
         return convolute(volume, wedge, kernel_in_fourier=True)
 
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.
@@ -1681,7 +1681,7 @@ class GeneralWedge(PyTomClass):
         
         return result
     
-    def toSphericalFunc(self, b, radius):
+    def to_spherical_func(self, b, radius):
         """Convert the wedge from real space to a spherical function.
         This function serves as an interface to FRM.
         @param b: Bandwidth of the spherical function.

--- a/pytom/bin/auto_focus_classify.py
+++ b/pytom/bin/auto_focus_classify.py
@@ -226,12 +226,12 @@ def paverage(particleList, norm, binning, verbose, outdir='./', gpuID=None):
 
                 result = vol(size_x,size_y,size_z)
                 result.setAll(0.0)
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
                 wedgeSum.setAll(0)
 
             # create spectral wedge weighting
             rotation = particleObject.getRotation()
-            wedge = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False, rotation.invert())
+            wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False, rotation.invert())
 
             wedgeSum += wedge
 
@@ -303,12 +303,12 @@ def paverage(particleList, norm, binning, verbose, outdir='./', gpuID=None):
 
                 result = xp.zeros((size_x, size_y, size_z),dtype=xp.float32)
 
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x, size_y, size_z)
                 wedgeSum *= 0
 
             # create spectral wedge weighting
             rotation = particleObject.getRotation()
-            wedge = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z, False, rotation.invert())
+            wedge = wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False, rotation.invert())
 
             wedgeSum += wedge
 

--- a/pytom/bin/average.py
+++ b/pytom/bin/average.py
@@ -44,7 +44,7 @@ def average(particleList, averageName, showProgressBar=False, verbose=False,
     @change: limit for wedgeSum set to 1% or particles to avoid division by small numbers - FF
     """
     from pytom.lib.pytom_volume import read, vol, reducedToFull
-    from pytom.basic.filter import lowpassFilter, rotateWeighting
+    from pytom.basic.filter import lowpassFilter, rotate_weighting
     from pytom.lib.pytom_volume import transformSpline as transform
     from pytom.basic.fourier import convolute
     from pytom.basic.structures import Reference
@@ -128,7 +128,7 @@ def average(particleList, averageName, showProgressBar=False, verbose=False,
             wedge = wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False, rotinvert)
         else:
             # > FF: interpol bugfix
-            wedge = rotateWeighting(weighting=wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False),
+            wedge = rotate_weighting(weighting=wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False),
                                     z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
                                     isReducedComplex=True, returnReducedComplex=True)
             # wedge = wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False, rotation=rotinvert)

--- a/pytom/bin/average.py
+++ b/pytom/bin/average.py
@@ -105,10 +105,10 @@ def average(particleList, averageName, showProgressBar=False, verbose=False,
             result.setAll(0.0)
 
             if analytWedge:
-                wedgeSum = wedgeInfo.returnWedgeVolume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z)
             else:
                 # > FF bugfix
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x, size_y, size_z)
                 # < FF
                 # > TH bugfix
                 # wedgeSum = vol(size_x,size_y,size_z)
@@ -125,17 +125,17 @@ def average(particleList, averageName, showProgressBar=False, verbose=False,
         ### create spectral wedge weighting
         if analytWedge:
             # > analytical buggy version
-            wedge = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z, False, rotinvert)
+            wedge = wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False, rotinvert)
         else:
             # > FF: interpol bugfix
-            wedge = rotateWeighting(weighting=wedgeInfo.returnWedgeVolume(size_x, size_y, size_z, False),
+            wedge = rotateWeighting(weighting=wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False),
                                     z1=rotinvert[0], z2=rotinvert[1], x=rotinvert[2], mask=None,
                                     isReducedComplex=True, returnReducedComplex=True)
-            # wedge = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z, False, rotation=rotinvert)
+            # wedge = wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False, rotation=rotinvert)
 
             # < FF
             # > TH bugfix
-            # wedgeVolume = wedgeInfo.returnWedgeVolume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z,
+            # wedgeVolume = wedgeInfo.return_wedge_volume(wedgeSizeX=size_x, wedgeSizeY=size_y, wedgeSizeZ=size_z,
             #                                    humanUnderstandable=True, rotation=rotinvert)
             # wedge = rotate(volume=wedgeVolume, rotation=rotinvert, imethod='linear')
             # < TH
@@ -286,7 +286,7 @@ def averageGPU(particleList, averageName, showProgressBar=False, verbose=False,
     wedgeInfo = particleList[0].getWedge().convert2numpy()
 
     # TODO ifftshift to shift centered spectrum back to corner!
-    wedgeZero = xp.fft.ifftshift(wedgeInfo.returnWedgeVolume(sx, sy, sz, True))
+    wedgeZero = xp.fft.ifftshift(wedgeInfo.return_wedge_volume(sx, sy, sz, True))
     wedge     = xp.zeros_like(wedgeZero, dtype=xp.float32)
     wedgeSum  = xp.zeros_like(wedge, dtype=xp.float32)
 
@@ -325,7 +325,7 @@ def averageGPU(particleList, averageName, showProgressBar=False, verbose=False,
 
         # get the wedge per particle because the wedge can differ
         wedgeInfo = particleObject.getWedge().convert2numpy()
-        wedgeZero = xp.fft.ifftshift(wedgeInfo.returnWedgeVolume(sx, sy, sz, True))
+        wedgeZero = xp.fft.ifftshift(wedgeInfo.return_wedge_volume(sx, sy, sz, True))
 
         # apply wedge to particle
         particle = (ifftnP(fftnP(particle, plan=fftplan) * wedgeZero, plan=fftplan)).real

--- a/pytom/bin/average.py
+++ b/pytom/bin/average.py
@@ -234,7 +234,7 @@ def averageGPU(particleList, averageName, showProgressBar=False, verbose=False,
     @change: limit for wedgeSum set to 1% or particles to avoid division by small numbers - FF
     """
     from pytom.agnostic.io import read, write, read_size
-    from pytom.agnostic.filter import bandpass as lowpassFilter, applyFourierFilterFull
+    from pytom.agnostic.filter import bandpass as lowpassFilter, apply_fourier_filter_full
     from pytom.voltools import transform
     from pytom.basic.structures import Reference
     from pytom.agnostic.normalise import mean0std1
@@ -374,7 +374,7 @@ def averageGPU(particleList, averageName, showProgressBar=False, verbose=False,
         write(f'{root}-WedgeSumInverted{ext}', xp.fft.fftshift(wedgeSum))
 
     # the wedge sum should already be centered in the corner ?
-    result = applyFourierFilterFull(result, wedgeSum)  # prev wedgeSumINV
+    result = apply_fourier_filter_full(result, wedgeSum)  # prev wedgeSumINV
 
     # do a low pass filter
     result = lowpassFilter(result, sx/2-2, (sx/2-1)/10.)[0]

--- a/pytom/bin/calculate_correlation_matrix.py
+++ b/pytom/bin/calculate_correlation_matrix.py
@@ -352,7 +352,7 @@ class CMWorker():
                 wf_rotation = f.getRotation().invert()
 
                 # wf.setRotation(Rotation(-rotation[1],-rotation[0],-rotation[2]))
-                # wf_vol = wf.returnWedgeVolume(vf.size_x(), vf.size_y(), vf.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
+                # wf_vol = wf.return_wedge_volume(vf.size_x(), vf.size_y(), vf.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
                 vf = lowpassFilter(vf, job["Frequency"], 0)[0]
 
                 if g.getFilename() != last_filename:
@@ -360,7 +360,7 @@ class CMWorker():
                     wg = g.getWedge().getWedgeObject()
                     wg_rotation = g.getRotation().invert()
                     # wg.setRotation(Rotation(-rotation[1],-rotation[0],-rotation[2]))
-                    # wg_vol = wg.returnWedgeVolume(vg.size_x(), vg.size_y(), vg.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
+                    # wg_vol = wg.return_wedge_volume(vg.size_x(), vg.size_y(), vg.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
                     vg = lowpassFilter(vg, job["Frequency"], 0)[0]
 
                     last_filename = g.getFilename()

--- a/pytom/classification/auto_focus_classify.py
+++ b/pytom/classification/auto_focus_classify.py
@@ -225,12 +225,12 @@ def paverage(particleList, norm, binning, verbose, outdir='./', gpuID=None):
 
                 result = vol(size_x,size_y,size_z)
                 result.setAll(0.0)
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x,size_y,size_z)
                 wedgeSum.setAll(0)
 
             # create spectral wedge weighting
             rotation = particleObject.getRotation()
-            wedge = wedgeInfo.returnWedgeVolume(size_x,size_y,size_z,False, rotation.invert())
+            wedge = wedgeInfo.return_wedge_volume(size_x,size_y,size_z,False, rotation.invert())
 
             wedgeSum += wedge
 
@@ -302,12 +302,12 @@ def paverage(particleList, norm, binning, verbose, outdir='./', gpuID=None):
 
                 result = xp.zeros((size_x, size_y, size_z),dtype=xp.float32)
 
-                wedgeSum = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z)
+                wedgeSum = wedgeInfo.return_wedge_volume(size_x, size_y, size_z)
                 wedgeSum *= 0
 
             # create spectral wedge weighting
             rotation = particleObject.getRotation()
-            wedge = wedgeInfo.returnWedgeVolume(size_x, size_y, size_z, False, rotation.invert())
+            wedge = wedgeInfo.return_wedge_volume(size_x, size_y, size_z, False, rotation.invert())
 
             wedgeSum += wedge
 

--- a/pytom/classification/calculate_correlation_matrix.py
+++ b/pytom/classification/calculate_correlation_matrix.py
@@ -351,7 +351,7 @@ class CMWorker():
                 wf_rotation = f.getRotation().invert()
 
                 # wf.setRotation(Rotation(-rotation[1],-rotation[0],-rotation[2]))
-                # wf_vol = wf.returnWedgeVolume(vf.size_x(), vf.size_y(), vf.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
+                # wf_vol = wf.return_wedge_volume(vf.size_x(), vf.size_y(), vf.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
                 vf = lowpassFilter(vf, job["Frequency"], 0)[0]
 
                 if g.getFilename() != last_filename:
@@ -359,7 +359,7 @@ class CMWorker():
                     wg = g.getWedge().getWedgeObject()
                     wg_rotation = g.getRotation().invert()
                     # wg.setRotation(Rotation(-rotation[1],-rotation[0],-rotation[2]))
-                    # wg_vol = wg.returnWedgeVolume(vg.size_x(), vg.size_y(), vg.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
+                    # wg_vol = wg.return_wedge_volume(vg.size_x(), vg.size_y(), vg.size_z(), True, -rotation[1],-rotation[0],-rotation[2])
                     vg = lowpassFilter(vg, job["Frequency"], 0)[0]
 
                     last_filename = g.getFilename()

--- a/pytom/gpu/gpuFunctions.py
+++ b/pytom/gpu/gpuFunctions.py
@@ -1,18 +1,18 @@
 from pytom.gpu.initialize import device, xp
 
-def applyFourierFilter(particle, filter):
+def apply_fourier_filter(particle, filter):
     return xp.fft.irfftn(xp.fft.rfftn(particle) * filter)
 
-def applyFourierFilterFull(particle, filter):
+def apply_fourier_filter_full(particle, filter):
     return xp.fft.ifftn(xp.fft.fftn(particle) * filter)
 
 def applyRotatedStaticFourierFilter(particle, filter, rotation, rotation_order='rzxz'):
-    return applyFourierFilter(particle, filter.transform(rotation=rotation, rotation_order=rotation_order))
+    return apply_fourier_filter(particle, filter.transform(rotation=rotation, rotation_order=rotation_order))
 
 def applyRotatedFilter(particle, filter, rotation, rotation_order='rzxz'):
-    return applyFourierFilter(particle, transform(filter, rotation=rotation, rotation_order=rotation_order, device=device))
+    return apply_fourier_filter(particle, transform(filter, rotation=rotation, rotation_order=rotation_order, device=device))
 
-def applyFourierFilters(particle, filters):
+def apply_fourier_filters(particle, filters):
     '''Apply a series of filters in fourier space to a real space object
     @param particle: 2D/3D image or volume
     @type particle: ndarray

--- a/pytom/gpu/gpuStructures.py
+++ b/pytom/gpu/gpuStructures.py
@@ -258,7 +258,7 @@ class GLocalAlignmentPlan():
             self.wedge_angles = wedge.getWedgeAngle()
         else:
             self.wedge_angles = None
-        wedgePart          = wedge.returnWedgeVolume(*self.volume.shape, humanUnderstandable=True).get()
+        wedgePart          = wedge.return_wedge_volume(*self.volume.shape, humanUnderstandable=True).get()
         self.rotatedWedge  = cp.array(wedgePart, dtype=cp.float32)
         self.wedgePart     = cp.fft.fftshift(wedgePart).astype(cp.float32)
         self.wedgeTex      = StaticVolume(self.rotatedWedge.copy(), device=self.device, interpolation=interpolation)
@@ -522,7 +522,7 @@ class GLocalAlignmentPlan():
         if wedge._type == 'Wedge3dCTF':
             self.wedge_angles = None
             self.wedge = wedge
-            wedgePart = wedge.returnWedgeVolume(*self.volume.shape, humanUnderstandable=True).astype(
+            wedgePart = wedge.return_wedge_volume(*self.volume.shape, humanUnderstandable=True).astype(
                 self.cp.float32).get()
             self.rotatedWedge = self.cp.array(wedgePart, dtype=self.cp.float32)
             self.wedgePart = self.cp.fft.fftshift(wedgePart)
@@ -539,7 +539,7 @@ class GLocalAlignmentPlan():
             else:
                 self.wedge_angles  = wedge_angles
                 self.wedge        = wedge
-                wedgePart         = wedge.returnWedgeVolume(*self.volume.shape,
+                wedgePart         = wedge.return_wedge_volume(*self.volume.shape,
                                                             humanUnderstandable=True).astype(self.cp.float32).get()
                 self.rotatedWedge = self.cp.array(wedgePart, dtype=self.cp.float32)
                 self.wedgePart    = self.cp.fft.fftshift(wedgePart)
@@ -895,7 +895,7 @@ class CCCPlan():
         else:
             mask = maskFull
 
-        wedgeVol = particleList[0].getWedge().convert2numpy().getWedgeObject().returnWedgeVolume(*mask.shape)
+        wedgeVol = particleList[0].getWedge().convert2numpy().getWedgeObject().return_wedge_volume(*mask.shape)
         wedge = fourier_reduced2full(wedgeVol, isodd=mask.shape[-1] % 2)
         lpf = xp.fft.fftshift(create_sphere(mask.shape, freq))
 

--- a/pytom/gui/frameParticlePicking.py
+++ b/pytom/gui/frameParticlePicking.py
@@ -453,9 +453,9 @@ class ParticlePick(GuiTabWidget):
                     from pytom.gui.guiFunctions import datatype, loadstar
 
                     metadata = loadstar(metafiles[0],dtype=datatype)
-                    tiltAngles = metadata['TiltAngle']
-                    w1 = int(numpy.round(tiltAngles.min()+90))
-                    w2 = int(90-numpy.round(tiltAngles.max()))
+                    tilt_angles = metadata['TiltAngle']
+                    w1 = int(numpy.round(tilt_angles.min()+90))
+                    w2 = int(90-numpy.round(tilt_angles.max()))
                 else:
                     w1,w2 = 30,30
 
@@ -1198,9 +1198,9 @@ class ParticlePick(GuiTabWidget):
                 from pytom.gui.guiFunctions import datatype, loadstar
 
                 metadata = loadstar(metafiles[0],dtype=datatype)
-                tiltAngles = metadata['TiltAngle']
-                self.widgets[mode + 'Wedge1'].setValue(int(numpy.round(tiltAngles.min()+90)))
-                self.widgets[mode + 'Wedge2'].setValue(int(90-numpy.round(tiltAngles.max())))
+                tilt_angles = metadata['TiltAngle']
+                self.widgets[mode + 'Wedge1'].setValue(int(numpy.round(tilt_angles.min()+90)))
+                self.widgets[mode + 'Wedge2'].setValue(int(90-numpy.round(tilt_angles.max())))
         except Exception as e:
             print(e)
 

--- a/pytom/gui/frameTomographicReconstruction.py
+++ b/pytom/gui/frameTomographicReconstruction.py
@@ -1270,12 +1270,12 @@ class TomographReconstruct(GuiTabWidget):
             first,last = 0, len(files)-1
             self.widgets[mode + 'FirstIndex'].setText( str(0))
             self.widgets[mode + 'LastIndex'].setText( str( len(files)-1) )
-            for n, tiltAngle in enumerate( metadata['TiltAngle']):
+            for n, tilt_angle in enumerate( metadata['TiltAngle']):
                 mrcfile = 'sorted_{:02d}.mrc'.format(n)
-                if tiltAngle - firstAngle < -0.1 and mrcfile in files:
+                if tilt_angle - firstAngle < -0.1 and mrcfile in files:
                     self.widgets[mode + 'FirstIndex'].setText(str(n+1+INFR))
 
-                if tiltAngle - lastAngle < 0.1 and mrcfile in files:
+                if tilt_angle - lastAngle < 0.1 and mrcfile in files:
                     self.widgets[mode + 'LastIndex'].setText(str(n+INFR))
 
             fi, li = int(self.widgets[mode+'FirstIndex'].text()), int(self.widgets[mode+'LastIndex'].text())

--- a/pytom/gui/guiFunctions.py
+++ b/pytom/gui/guiFunctions.py
@@ -1112,8 +1112,8 @@ def parseImodShiftFile(imodShiftFile):
     return data[:, -2:]
 
 def addShiftToMarkFrames(mark_frames, shifts, metadata, excluded):
-    tiltAngles = metadata['TiltAngle'][excluded]
-    zeroIndex = abs(tiltAngles).argmin()
+    tilt_angles = metadata['TiltAngle'][excluded]
+    zeroIndex = abs(tilt_angles).argmin()
     zerox, zeroy = shifts[zeroIndex]*0
 
     for i in range(len(mark_frames)):

--- a/pytom/lib/frm.py
+++ b/pytom/lib/frm.py
@@ -967,10 +967,10 @@ def frm_correlate(vf, wf, vg, wg, b, max_freq, weights=None, ps=False, denominat
         # if _last_bw != bw:
         #     # mf = create_wedge_sf(wf[0], wf[1], bw)
         #     # mg = create_wedge_sf(wg[0], wg[1], bw)
-        #     mf = wf.toSphericalFunc(bw)
-        #     mg = wg.toSphericalFunc(bw)
-        mf = wf.toSphericalFunc(bw, r)
-        mg = wg.toSphericalFunc(bw, r)
+        #     mf = wf.to_spherical_func(bw)
+        #     mg = wg.to_spherical_func(bw)
+        mf = wf.to_spherical_func(bw, r)
+        mg = wg.to_spherical_func(bw, r)
 
         if ps:
             corr1, corr2, corr3 = sph_correlate_ps(vol2sf(ff, r, bw), mf, vol2sf(gg, r, bw), mg, to_calculate)

--- a/pytom/localization/extractPeaks.py
+++ b/pytom/localization/extractPeaks.py
@@ -146,7 +146,7 @@ def extractPeaks(volume, reference, rotations, scoreFnc=None, mask=None, maskIsS
     return [result, orientation, sumV, sqrV]
 
 
-def create_structured_wedge(tilt_angles, angle2=None, cutoffRadius=10, size_x=10, size_y=10, size_z=10, smooth=0, rotation=None, c=1):
+def create_structured_wedge(tilt_angles, angle2=None, cutoff_radius=10, size_x=10, size_y=10, size_z=10, smooth=0, rotation=None, c=1):
     from pytom.gpu.initialize import xp
     print(tilt_angles)
     z, y, x = xp.meshgrid(xp.arange(-size_y // 2 + size_y % 2, size_y // 2 + size_y % 2),
@@ -165,7 +165,7 @@ def create_structured_wedge(tilt_angles, angle2=None, cutoffRadius=10, size_x=10
             tot += (abs(xp.sin(alpha)*(x-y/xp.tan(alpha))) <= c)*1
 
     tot[tot>1] = 1
-    tot[r > cutoffRadius] = 0
+    tot[r > cutoff_radius] = 0
     return xp.fft.fftshift(tot, axes=(0, 1))
 
 
@@ -220,7 +220,7 @@ def templateMatchingGPU(volume, reference, rotations, scoreFnc=None, mask=None, 
     if w1 > 1E-3 or w2 > 1E-3:
         # cutoff was previously sx // 2 - 1
         # replace with Wedge.convert2numpy() and the return_wedge_volume
-        cutoff = wedgeInfo._wedgeObject._cutoffRadius
+        cutoff = wedgeInfo._wedgeObject._cutoff_radius
         smooth = wedgeInfo._wedgeObject._smooth
         wedge = create_wedge(w1, w2, cutoff, sx, sy, sz, smooth).get().astype(np.float32)
         wedge_tomogram = create_wedge(w1, w2, cutoff, SX, SY, SZ, smooth).get().astype(np.float32)

--- a/pytom/localization/extractPeaks.py
+++ b/pytom/localization/extractPeaks.py
@@ -219,7 +219,7 @@ def templateMatchingGPU(volume, reference, rotations, scoreFnc=None, mask=None, 
 
     if w1 > 1E-3 or w2 > 1E-3:
         # cutoff was previously sx // 2 - 1
-        # replace with Wedge.convert2numpy() and the returnWedgeVolume
+        # replace with Wedge.convert2numpy() and the return_wedge_volume
         cutoff = wedgeInfo._wedgeObject._cutoffRadius
         smooth = wedgeInfo._wedgeObject._smooth
         wedge = create_wedge(w1, w2, cutoff, sx, sy, sz, smooth).get().astype(np.float32)

--- a/pytom/polishing/reconstruct_local_alignment.py
+++ b/pytom/polishing/reconstruct_local_alignment.py
@@ -211,7 +211,7 @@ def run_single_tilt_angle(subtomogram, ang, offset, vol_size, particle_position,
     from math import cos, sin, pi, sqrt
     from pytom.agnostic.tools import create_circle
     from pytom.agnostic.transform import cut_from_projection
-    from pytom.agnostic.filter import applyFourierFilterFull, bandpass_circle
+    from pytom.agnostic.filter import apply_fourier_filter_full, bandpass_circle
     from pytom.agnostic.io import read, write
     from pytom.agnostic.correlation import meanUnderMask, stdUnderMask
     import os
@@ -233,7 +233,7 @@ def run_single_tilt_angle(subtomogram, ang, offset, vol_size, particle_position,
         profile = [line.split()[0] for line in open(fsc_path, 'r').readlines()]
         fsc_mask3d = profile_to_fourier_vol(profile, subtomogram.shape)
 
-        subtomogram = applyFourierFilterFull(subtomogram, fsc_mask3d)
+        subtomogram = apply_fourier_filter_full(subtomogram, fsc_mask3d)
 
 
     # Cross correlate the templat
@@ -264,7 +264,7 @@ def run_single_tilt_angle(subtomogram, ang, offset, vol_size, particle_position,
         if os.path.isfile(fsc_path):
             profile = [line.split()[0] for line in open(fsc_path, 'r').readlines()]
             fsc_mask2d = profile_to_fourier_vol(profile, patch.shape)
-            patch = applyFourierFilterFull(patch, fsc_mask2d)
+            patch = apply_fourier_filter_full(patch, fsc_mask2d)
 
 
         template = normalize_image(template, mask2d, mask2d.sum())
@@ -355,7 +355,7 @@ def run_single_tilt_angle(subtomogram, ang, offset, vol_size, particle_position,
             ax_2_2.axis('off')
 
             axis_title(ax_0_0, "Cutout")
-            ax_0_0.imshow(applyFourierFilterFull(patch,xp.fft.fftshift(ff)))
+            ax_0_0.imshow(apply_fourier_filter_full(patch,xp.fft.fftshift(ff)))
             axis_title(ax_0_1, "Template")
             ax_0_1.imshow(template)
             axis_title(ax_0_2, "Shifted Cutout\n(based on cross correlation)")

--- a/pytom/polishing/reconstruct_local_alignment.py
+++ b/pytom/polishing/reconstruct_local_alignment.py
@@ -227,11 +227,11 @@ def run_single_tilt_angle(subtomogram, ang, offset, vol_size, particle_position,
         '/data/gijsvds/ctem/05_Subtomogram_Analysis/Alignment/GLocal/mask_200_75_5.mrc')
 
     import os
-    from pytom.agnostic.filter import filter_volume_by_profile, profile2FourierVol
+    from pytom.agnostic.filter import filter_volume_by_profile, profile_to_fourier_vol
     fsc_path = ''
     if os.path.isfile(fsc_path):
         profile = [line.split()[0] for line in open(fsc_path, 'r').readlines()]
-        fsc_mask3d = profile2FourierVol(profile, subtomogram.shape)
+        fsc_mask3d = profile_to_fourier_vol(profile, subtomogram.shape)
 
         subtomogram = applyFourierFilterFull(subtomogram, fsc_mask3d)
 
@@ -263,7 +263,7 @@ def run_single_tilt_angle(subtomogram, ang, offset, vol_size, particle_position,
 
         if os.path.isfile(fsc_path):
             profile = [line.split()[0] for line in open(fsc_path, 'r').readlines()]
-            fsc_mask2d = profile2FourierVol(profile, patch.shape)
+            fsc_mask2d = profile_to_fourier_vol(profile, patch.shape)
             patch = applyFourierFilterFull(patch, fsc_mask2d)
 
 

--- a/pytom/pytomc/sh_alignment/frm.py
+++ b/pytom/pytomc/sh_alignment/frm.py
@@ -967,10 +967,10 @@ def frm_correlate(vf, wf, vg, wg, b, max_freq, weights=None, ps=False, denominat
         # if _last_bw != bw:
         #     # mf = create_wedge_sf(wf[0], wf[1], bw)
         #     # mg = create_wedge_sf(wg[0], wg[1], bw)
-        #     mf = wf.toSphericalFunc(bw)
-        #     mg = wg.toSphericalFunc(bw)
-        mf = wf.toSphericalFunc(bw, r)
-        mg = wg.toSphericalFunc(bw, r)
+        #     mf = wf.to_spherical_func(bw)
+        #     mg = wg.to_spherical_func(bw)
+        mf = wf.to_spherical_func(bw, r)
+        mg = wg.to_spherical_func(bw, r)
 
         if ps:
             corr1, corr2, corr3 = sph_correlate_ps(vol2sf(ff, r, bw), mf, vol2sf(gg, r, bw), mg, to_calculate)

--- a/pytom/reconstruction/TiltAlignmentStructures.py
+++ b/pytom/reconstruction/TiltAlignmentStructures.py
@@ -471,7 +471,7 @@ class TiltSeries(PyTomClass):
             if not (binning == 1) or (binning == None):
                 image = resize(volume=image, factor=1 / float(binning))[0]
             if lowpassFilter:
-                filtered = filterFunction(volume=image, filterObject=lpf, fourierOnly=False)
+                filtered = filterFunction(volume=image, filterObject=lpf, fourier_only=False)
                 image = filtered[0]
 
             tiltAngle = projection._tiltAngle

--- a/pytom/reconstruction/TiltAlignmentStructures.py
+++ b/pytom/reconstruction/TiltAlignmentStructures.py
@@ -85,7 +85,7 @@ class TiltSeries(PyTomClass):
                     fname = tiltSeriesName + "_" + str( ii ) + "." + tiltSeriesFormat
                     if alignedTiltSeriesName:
                         proj = Projection(filename=fname,
-                                          index=ii, tiltAngle=self.mf[0,cnt,0],
+                                          index=ii, tilt_angle=self.mf[0,cnt,0],
                                           offsetX=0., offsetY=0.,
                                           alignmentTransX=0., alignmentTransY=0.,
                                           alignmentRotation=0., alignmentMagnification=1.)
@@ -95,7 +95,7 @@ class TiltSeries(PyTomClass):
                     else:
         
                         proj = Projection(filename=fname,
-                                          index=ii, tiltAngle=self.mf[0,cnt,0],
+                                          index=ii, tilt_angle=self.mf[0,cnt,0],
                                           offsetX=0., offsetY=0.,
                                           alignmentTransX=0., alignmentTransY=0.,
                                           alignmentRotation=0., alignmentMagnification=1.)
@@ -119,7 +119,7 @@ class TiltSeries(PyTomClass):
 
                     if alignedTiltSeriesName:
                         proj = Projection(filename=fname,
-                                          index=ii, tiltAngle=self.mf[0,ii,0],
+                                          index=ii, tilt_angle=self.mf[0,ii,0],
                                           offsetX=0., offsetY=0.,
                                           alignmentTransX=0., alignmentTransY=0.,
                                           alignmentRotation=0., alignmentMagnification=1.)
@@ -129,7 +129,7 @@ class TiltSeries(PyTomClass):
                     else:
                         
                         proj = Projection(filename=fname,
-                                          index=ii, tiltAngle=self.mf[0,ii,0],
+                                          index=ii, tilt_angle=self.mf[0,ii,0],
                                           offsetX=0., offsetY=0.,
                                           alignmentTransX=0., alignmentTransY=0.,
                                           alignmentRotation=0., alignmentMagnification=1.)
@@ -171,14 +171,14 @@ class TiltSeries(PyTomClass):
         """
         tline = ""
         for (ii, projection) in enumerate(self._ProjectionList):
-            tiltAngle = projection._tiltAngle
+            tilt_angle = projection._tilt_angle
             transX = -projection._alignmentTransX
             transY = -projection._alignmentTransY
             rot = -(projection._alignmentRotation + 90.)
             mag = projection._alignmentMagnification
             tline = tline + ("%3d: " % ii)
             tline = tline + ("%15s; " % projection._filename)
-            tline = tline + ("tiltAngle=%9.3f; " % tiltAngle)
+            tline = tline + ("tiltAngle=%9.3f; " % tilt_angle)
             tline = tline + ("transX=%9.3f; " % transX)
             tline = tline + ("transY=%9.3f; " % transY)
             tline = tline + ("rot=%9.3f; " % rot)
@@ -209,7 +209,7 @@ class TiltSeries(PyTomClass):
         projs = []
         for ii in self._projIndices:
             proj = Projection(filename=None,
-                              index=ii, tiltAngle=None,
+                              index=ii, tilt_angle=None,
                               offsetX=0., offsetY=0.,
                               alignmentTransX=0., alignmentTransY=0.,
                               alignmentRotation=0., alignmentMagnification=1.)
@@ -300,12 +300,12 @@ class TiltSeries(PyTomClass):
 
         # check that tilt angles in marker file and projections are the same
         for (iproj, proj) in enumerate(self._ProjectionList._list):
-            tiltAngle = markerFile[0, iproj, 0]
-            proj._tiltAngle = tiltAngle
-            if abs(tiltAngle - proj._tiltAngle) > 0.01:
+            tilt_angle = markerFile[0, iproj, 0]
+            proj._tilt_angle = tilt_angle
+            if abs(tilt_angle - proj._tilt_angle) > 0.01:
                 print(("Warning: tilt angles in Projection " + str(iproj + 1)
                       + " differ in markerFile"))
-                print(("MarkerFile: %4.1f" % tiltAngle) + (" vs. image Header: %4.1f" % proj._tiltAngle))
+                print(("MarkerFile: %4.1f" % tilt_angle) + (" vs. image Header: %4.1f" % proj._tilt_angle))
 
         # delete old markerFiles
         if (len(self._Markers) > 0):
@@ -365,21 +365,21 @@ class TiltSeries(PyTomClass):
 
         @param tltfile: file containing tilt angles - typically end on .tlt or .rawtlt
         @type tltfile: str
-        @return: tiltAngles
+        @return: tilt_angles
         @rtype: list
 
         @author: FF
         """
-        from pytom.reconstruction.tiltAlignmentFunctions import readIMODtiltAngles
+        from pytom.reconstruction.tiltAlignmentFunctions import readIMODtilt_angles
 
-        tiltAngles = readIMODtiltAngles(tltfile)
-        if len(tiltAngles) != len(self._ProjectionList):
-            print("Number of tilt angles in tiltfile:   " + len(tiltAngles))
+        tilt_angles = readIMODtilt_angles(tltfile)
+        if len(tilt_angles) != len(self._ProjectionList):
+            print("Number of tilt angles in tiltfile:   " + len(tilt_angles))
             print("Number of tilt angles in tiltseries: " + len(self._ProjectionList))
             raise IndexError('Number of tilt angles in tltfile does not match TiltSeries')
         for (iproj, proj) in enumerate(self._ProjectionList):
-            proj._tiltAngle = tiltAngles[iproj]
-        return tiltAngles
+            proj._tilt_angle = tilt_angles[iproj]
+        return tilt_angles
 
     def writeMarkerFile(self, markerFileName):
         """
@@ -397,7 +397,7 @@ class TiltSeries(PyTomClass):
                 markerFileVol.setV(Marker.get_xProj(itilt), 1, itilt, imark)
                 markerFileVol.setV(Marker.get_yProj(itilt), 2, itilt, imark)
                 if imark == 0:
-                    markerFileVol.setV(int(round(proj._tiltAngle)), 0, int(itilt), int(imark))
+                    markerFileVol.setV(int(round(proj._tilt_angle)), 0, int(itilt), int(imark))
         markerFileVol.write(markerFileName)
 
     def write_aligned_projs(self, weighting=None, lowpassFilter=None, binning=1, verbose=False, write_images=True):
@@ -474,10 +474,10 @@ class TiltSeries(PyTomClass):
                 filtered = filterFunction(volume=image, filterObject=lpf, fourier_only=False)
                 image = filtered[0]
 
-            tiltAngle = projection._tiltAngle
+            tilt_angle = projection._tilt_angle
             if verbose:
-                print("tiltAngle=%2.2f" % tiltAngle)
-            header.set_tiltangle(tiltAngle)
+                print("tiltAngle=%2.2f" % tilt_angle)
+            header.set_tiltangle(tilt_angle)
             newFilename = (filename + "_" + str(projection.getIndex()) + '.em')
             write_em(filename=newFilename, data=image, header=header)
 
@@ -505,10 +505,10 @@ class TiltSeries(PyTomClass):
             # ar = loadstar(alignResultFile, dtype=DATATYPE_ALIGNMENT_RESULTS)
             # for (kk, filename) in enumerate(ar['FileName']):
             #     filename=str(filename)
-            #     tiltAngle = ar['TiltAngle'][kk]
+            #     tilt_angle = ar['TiltAngle'][kk]
             #     proj = Projection(filename=filename,
             #                       alignedFilename=filename,
-            #                       index=kk, tiltAngle=tiltAngle,
+            #                       index=kk, tilt_angle=tilt_angle,
             #                       offsetX=0., offsetY=0.,
             #                       alignmentTransX=0., alignmentTransY=0.,
             #                       alignmentRotation=0., alignmentMagnification=1.)
@@ -518,9 +518,9 @@ class TiltSeries(PyTomClass):
             projs = []
             for (kk, ii) in enumerate(self._projIndices):
                 print(self._alignedTiltSeriesName + "_" + str(ii) + "." + self._tiltSeriesFormat)
-                tiltAngle = self._ProjectionList[kk]._tiltAngle
+                tilt_angle = self._ProjectionList[kk]._tilt_angle
                 proj = Projection(filename=self._alignedTiltSeriesName + "_" + str(ii) + "." + self._tiltSeriesFormat,
-                                  index=ii, tiltAngle=tiltAngle,
+                                  index=ii, tilt_angle=tilt_angle,
                                   offsetX=0., offsetY=0.,
                                   alignmentTransX=0., alignmentTransY=0.,
                                   alignmentRotation=0., alignmentMagnification=1.)
@@ -577,8 +577,8 @@ class TiltAlignment:
         self._alignmentRotations = numpy.array(self._ntilt * [0.])
         self._alignmentMagnifications = numpy.array(self._ntilt * [1.])
         self._alignmentBeamTilt = 0.
-        # get tilt angles from projections, stored in self._tiltAngles, self._cTilt, self._sTilt
-        self._tiltAngles = numpy.array(self._ntilt * [0.])
+        # get tilt angles from projections, stored in self._tilt_angles, self._cTilt, self._sTilt
+        self._tilt_angles = numpy.array(self._ntilt * [0.])
         self._cTilt = numpy.array(self._ntilt * [0.])
         self._sTilt = numpy.array(self._ntilt * [0.])
         self.getTiltAnglesFromTiltSeries(TiltSeries_)
@@ -598,14 +598,14 @@ class TiltAlignment:
         """
         tline = ""
         for ii in range(0, self._ntilt):
-            tiltAngle = self._tiltAngles[ii]
+            tilt_angle = self._tilt_angles[ii]
             transX = -self._alignmentTransX[ii]
             transY = -self._alignmentTransY[ii]
             rot = -(self._alignmentRotations[ii] + 90.)
             mag = self._alignmentMagnifications[ii]
 
             tline = tline + ("%3d: " % ii)
-            tline = tline + ("tiltAngle=%8.3f; " % tiltAngle)
+            tline = tline + ("tiltAngle=%8.3f; " % tilt_angle)
             tline = tline + ("transX=%9.3f; " % transX)
             tline = tline + ("transY=%9.3f; " % transY)
             tline = tline + ("rot=%9.3f; " % rot)
@@ -769,15 +769,15 @@ class TiltAlignment:
             print("Houston: We have a problem!")
         # initialize alignment in seperate array - easier for optimization
         # sin and cos
-        self._tiltAngles = numpy.array(self._ntilt * [0.])
+        self._tilt_angles = numpy.array(self._ntilt * [0.])
         self._cTilt = numpy.array(self._ntilt * [0.])
         self._sTilt = numpy.array(self._ntilt * [0.])
         for (kk, proj) in enumerate(TiltSeries_._ProjectionList._list):
             the = proj.getTiltAngle()
-            self._tiltAngles[kk] = the
+            self._tilt_angles[kk] = the
             self._sTilt[kk] = sin(the / 180. * pi)
             self._cTilt[kk] = cos(the / 180. * pi)
-        return self._tiltAngles
+        return self._tilt_angles
 
     def getTiltAnglesFromIMODfile(self, tltfile):
         """
@@ -785,24 +785,24 @@ class TiltAlignment:
 
         @param tltfile: file containing tilt angles - typically end on .tlt or .rawtlt
         @type tltfile: str
-        @return: tiltAngles
+        @return: tilt_angles
         @rtype: list
 
         @author: FF
         """
-        from pytom.reconstruction.tiltAlignmentFunctions import readIMODtiltAngles
+        from pytom.reconstruction.tiltAlignmentFunctions import readIMODtilt_angles
         from math import sin, cos, pi
 
-        tiltAngles = readIMODtiltAngles(tltfile)
-        self._ntilt = len(tiltAngles)
-        self._tiltAngles = numpy.array(self._ntilt * [0.])
+        tilt_angles = readIMODtilt_angles(tltfile)
+        self._ntilt = len(tilt_angles)
+        self._tilt_angles = numpy.array(self._ntilt * [0.])
         self._cTilt = numpy.array(self._ntilt * [0.])
         self._sTilt = numpy.array(self._ntilt * [0.])
-        for ii in range(0, len(tiltAngles)):
-            self._tiltAngles[ii] = tiltAngles[ii]
-            self._sTilt[ii] = sin(tiltAngles[ii] / 180. * pi)
-            self._cTilt[ii] = cos(tiltAngles[ii] / 180. * pi)
-        return self._tiltAngles
+        for ii in range(0, len(tilt_angles)):
+            self._tilt_angles[ii] = tilt_angles[ii]
+            self._sTilt[ii] = sin(tilt_angles[ii] / 180. * pi)
+            self._cTilt[ii] = cos(tilt_angles[ii] / 180. * pi)
+        return self._tilt_angles
 
     def randomize(self, amplitude):
         """
@@ -859,7 +859,7 @@ class TiltAlignment:
                                   Markers_=self._Markers[start:end],
                                   cTilt=self._cTilt, sTilt=self._sTilt,
                                   transX=self._alignmentTransX, transY=self._alignmentTransY,
-                                  rotInPlane=self._alignmentRotations, tiltangles=self._tiltAngles,
+                                  rotInPlane=self._alignmentRotations, tiltangles=self._tilt_angles,
                                   isoMag=self._alignmentMagnifications, dBeam=self._alignmentBeamTilt,
                                   dMagnFocus=None, dRotFocus=None, equationSet=False,
                                   irefmark=self.TiltSeries_._TiltAlignmentParas.irefmark, logfile_residual=logfile,
@@ -882,7 +882,7 @@ class TiltAlignment:
                                    Markers_=self._Markers,
                                    cTilt=self._cTilt, sTilt=self._sTilt,
                                    transX=self._alignmentTransX, transY=self._alignmentTransY,ireftilt=self.ireftilt,
-                                   rotInPlane=self._alignmentRotations,irefmark=self.irefmark, tiltangles=self._tiltAngles,
+                                   rotInPlane=self._alignmentRotations,irefmark=self.irefmark, tiltangles=self._tilt_angles,
                                    isoMag=self._alignmentMagnifications, dBeam=self._alignmentBeamTilt,
                                    dMagnFocus=None, dRotFocus=None, equationSet=True)
         else:
@@ -925,7 +925,7 @@ class TiltAlignment:
                                                          rotInPlane=self._alignmentRotations,
                                                          irefmark=self.irefmark,
                                                          ireftilt=self.ireftilt,
-                                                         tiltangles=self._tiltAngles,
+                                                         tiltangles=self._tilt_angles,
                                                          isoMag=self._alignmentMagnifications,
                                                          dBeam=self._alignmentBeamTilt,
                                                          dMagnFocus=None, dRotFocus=None, equationSet=True)
@@ -963,7 +963,7 @@ class TiltAlignment:
             print("New irefmark: " + str(TiltAlignmentParameters_.irefmark))
 
         if not (TiltAlignmentParameters_.ireftilt in self._projIndices.astype(int)):
-            TiltAlignmentParameters_.ireftilt = abs(self._tiltAngles).argmin()
+            TiltAlignmentParameters_.ireftilt = abs(self._tilt_angles).argmin()
             print("Warning: ireftilt must be in range of projection indices")
             print("New ireftilt: " + str(TiltAlignmentParameters_.ireftilt))
 
@@ -1262,7 +1262,7 @@ class TiltAlignment:
             Markers_=self._Markers,
             cTilt=self._cTilt, sTilt=self._sTilt, ireftilt=self.ireftilt,
             transX=self._alignmentTransX, transY=self._alignmentTransY,
-            rotInPlane=self._alignmentRotations, tiltangles=self._tiltAngles,
+            rotInPlane=self._alignmentRotations, tiltangles=self._tilt_angles,
             isoMag=self._alignmentMagnifications, dBeam=self._alignmentBeamTilt,
             dMagnFocus=None, dRotFocus=None, equationSet=False, irefmark=self.irefmark)
 
@@ -1292,7 +1292,7 @@ class TiltAlignment:
             Markers_=self._Markers,
             cTilt=self._cTilt, sTilt=self._sTilt,
             transX=self._alignmentTransX, transY=self._alignmentTransY, ireftilt=self.ireftilt,
-            rotInPlane=self._alignmentRotations, irefmark=self.irefmark, tiltangles=self._tiltAngles,
+            rotInPlane=self._alignmentRotations, irefmark=self.irefmark, tiltangles=self._tilt_angles,
             isoMag=self._alignmentMagnifications, dBeam=self._alignmentBeamTilt,
             dMagnFocus=None, dRotFocus=None, equationSet=False, logfile_residual=logfile_residual)
 
@@ -1321,7 +1321,7 @@ class TiltAlignment:
                                    cTilt=self._cTilt, sTilt=self._sTilt,
                                    transX=self._alignmentTransX, transY=self._alignmentTransY, ireftilt=self.ireftilt,
                                    rotInPlane=self._alignmentRotations, irefmark=self.irefmark,
-                                   tiltangles=self._tiltAngles,
+                                   tiltangles=self._tilt_angles,
                                    isoMag=self._alignmentMagnifications, dBeam=self._alignmentBeamTilt,
                                    dMagnFocus=None, dRotFocus=None, equationSet=False,
                                    logfile_residual=logfile_residual, verbose=True, errorRef=True)
@@ -1402,7 +1402,7 @@ class TiltAlignment:
     #         print("New irefmark: " + str(TiltAlignmentParameters_.irefmark))
     #
     #     if not (TiltAlignmentParameters_.ireftilt in self._projIndices.astype(int)):
-    #         TiltAlignmentParameters_.ireftilt = abs(self._tiltAngles).argmin() + 1
+    #         TiltAlignmentParameters_.ireftilt = abs(self._tilt_angles).argmin() + 1
     #         print("Warning: ireftilt must be in range of projection indices")
     #         print("New ireftilt: " + str(TiltAlignmentParameters_.ireftilt))
     #

--- a/pytom/reconstruction/imageStructures.py
+++ b/pytom/reconstruction/imageStructures.py
@@ -167,7 +167,7 @@ class Image(PyTomClass):
         from pytom.basic.filter import bandpassFilter
 
         res = bandpassFilter(volume=self.data, lowestFrequency=lowfreq,
-                             highestFrequency=hifreq, bpf=None, smooth=smooth, fourierOnly=False)
+                             highestFrequency=hifreq, bpf=None, smooth=smooth, fourier_only=False)
         self.data = res[0]
         bpf = res[1]
         return bpf
@@ -189,7 +189,7 @@ class Image(PyTomClass):
         res = bandpassFilter(volume=self.data,
                              lowestFrequency=lowfreq * self.dims[0] / 2.,
                              highestFrequency=hifreq * self.dims[0] / 2., bpf=None,
-                             smooth=smooth * self.dims[0] / 2., fourierOnly=False)
+                             smooth=smooth * self.dims[0] / 2., fourier_only=False)
         self.data = res[0]
         bpf = res[1]
         return bpf

--- a/pytom/reconstruction/reconstruct_INFR.py
+++ b/pytom/reconstruction/reconstruct_INFR.py
@@ -43,9 +43,9 @@ if __name__ == '__main__':
 
     if metafile and os.path.exists(metafile):
         metadata = loadstar(metafile, dtype=datatype)
-        tiltAngles = metadata['TiltAngle']
+        tilt_angles = metadata['TiltAngle']
     else:
-        tiltAngles = []
+        tilt_angles = []
 
     metafile = '' if metafile is None or not os.path.exists(metafile) else metafile
 

--- a/pytom/reconstruction/reconstructionFunctions.py
+++ b/pytom/reconstruction/reconstructionFunctions.py
@@ -39,12 +39,12 @@ def adjustPickPositionInParticleList(particleList,offsetZ,binning,centerX,center
     return particleList
     
         
-def positionInProjection(location3D, tiltAngle, tiltAxis='Y'):
+def positionInProjection(location3D, tilt_angle, tiltAxis='Y'):
     """
     positionInProjection:
     @param location3D: [x,y,z] vector of particle positions in tomogram
-    @param tiltAngle: tilt angle
-    @type tiltAngle: float
+    @param tilt_angle: tilt angle
+    @type tilt_angle: float
     @param tiltAxis: Set tilt axis of projections. 'Y' is default.
     @type tiltAxis: str
     @return: 2D Position vector [x,y]
@@ -52,13 +52,13 @@ def positionInProjection(location3D, tiltAngle, tiltAxis='Y'):
     """
     if tiltAxis == 'X':
         from pytom.tools.maths import XRotationMatrix
-        rotationMatrix = XRotationMatrix(tiltAngle) 
+        rotationMatrix = XRotationMatrix(tilt_angle) 
     elif tiltAxis == 'Y':
         from pytom.tools.maths import YRotationMatrix
-        rotationMatrix = YRotationMatrix(tiltAngle)
+        rotationMatrix = YRotationMatrix(tilt_angle)
     elif tiltAxis == 'Z':
         from pytom.tools.maths import ZRotationMatrix
-        rotationMatrix = ZRotationMatrix(tiltAngle)
+        rotationMatrix = ZRotationMatrix(tilt_angle)
 
     position2D = rotationMatrix * location3D
 
@@ -228,7 +228,7 @@ def alignWeightReconstruct(tiltSeriesName, markerFileName, lastProj, tltfile=Non
             # for n, i in enumerate(tiltAlignment._projIndices.astype(int)):
             #
             #
-            #     print("{:3.0f} {:6.0f} {:6.0f} {:6.0f} {:6.0f}".format(tiltAlignment._tiltAngles[n],
+            #     print("{:3.0f} {:6.0f} {:6.0f} {:6.0f} {:6.0f}".format(tiltAlignment._tilt_angles[n],
             #           tiltAlignment._Markers[tiltSeries._TiltAlignmentParas.irefmark].xProj[n],
             #           tiltAlignment._Markers[tiltSeries._TiltAlignmentParas.irefmark].yProj[n],
             #           tiltSeries._ProjectionList[int(n)]._alignmentTransX,
@@ -244,7 +244,7 @@ def alignWeightReconstruct(tiltSeriesName, markerFileName, lastProj, tltfile=Non
 
             # Retrieve the two relevant angles
             inPlaneAng = tiltAlignment._alignmentRotations[ireftilt]
-            tiltAng = tiltAlignment._tiltAngles[ireftilt]
+            tiltAng = tiltAlignment._tilt_angles[ireftilt]
 
             # Retrieve the original pick position
             xx = tiltAlignment._Markers[tiltSeries._TiltAlignmentParas.irefmark].xProj[ireftilt]
@@ -309,7 +309,7 @@ def alignWeightReconstruct(tiltSeriesName, markerFileName, lastProj, tltfile=Non
 
 
 # TODO why is this function here?????
-def rotate_vector3D(point3D, centerPoint3D, shift3D, inPlaneRotAngle, tiltAngle):
+def rotate_vector3D(point3D, centerPoint3D, shift3D, inPlaneRotAngle, tilt_angle):
     from pytom.tools.maths import rotate_vector2d
     from numpy import sin, cos, pi
 
@@ -326,9 +326,9 @@ def rotate_vector3D(point3D, centerPoint3D, shift3D, inPlaneRotAngle, tiltAngle)
     xmod, ymod = rotate_vector2d(newPoint[:2], cpsi, spsi)
     zmod = newPoint[2]
 
-    # In-plane rotation of x and z coordinate over tiltAngle
-    sTilt = sin(tiltAngle / 180. * pi)
-    cTilt = cos(tiltAngle / 180. * pi)
+    # In-plane rotation of x and z coordinate over tilt_angle
+    sTilt = sin(tilt_angle / 180. * pi)
+    cTilt = cos(tilt_angle / 180. * pi)
     xmod,zmod = rotate_vector2d([xmod,zmod], cTilt, sTilt)
 
     rotatedNewPoint = [xmod, ymod, zmod]
@@ -395,7 +395,7 @@ def alignImagesUsingAlignmentResultFile(alignmentResultsFile, weighting=None, lo
         aty = alignmentResults['AlignmentTransY'][n]
         rot = alignmentResults['InPlaneRotation'][n]
         mag = 1 / (alignmentResults['Magnification'][n])
-        projection = Projection(imageList[n], tiltAngle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
+        projection = Projection(imageList[n], tilt_angle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
                                 alignmentRotation=rot, alignmentMagnification=mag)
         projectionList.append(projection)
 
@@ -411,7 +411,7 @@ def alignImagesUsingAlignmentResultFile(alignmentResultsFile, weighting=None, lo
         if binning > 1:
             image = resize(image, 1 / binning)
 
-        tiltAngle = projection._tiltAngle
+        tilt_angle = projection._tilt_angle
 
         # 1 -- normalize to contrast - subtract mean and norm to mean
         immean = image.mean()
@@ -461,7 +461,7 @@ def alignImagesUsingAlignmentResultFile(alignmentResultsFile, weighting=None, lo
             # image = (ifft(complexRealMult(fft(image), w_func)) / (image.size_x() * image.size_y() * image.size_z()))
             image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
         elif (weighting != None) and (weighting > 0):
-            weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
+            weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tilt_angle, imdim, imdim, slice_width))
             image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
 
         thetaStack[ii] = float(round(projection.getTiltAngle() - angle_specimen))

--- a/pytom/reconstruction/reconstructionFunctions.py
+++ b/pytom/reconstruction/reconstructionFunctions.py
@@ -369,7 +369,7 @@ def alignImagesUsingAlignmentResultFile(alignmentResultsFile, weighting=None, lo
         imdimY = int(float(imdimY) / float(binning) + .5)
 
     imdim = max(imdimY, imdimX)
-    sliceWidth = imdim
+    slice_width = imdim
 
     if (weighting != None) and (float(weighting) < -0.001):
         cfreq = abs(tilt_angles[1:]-tilt_angles[:-1])
@@ -461,7 +461,7 @@ def alignImagesUsingAlignmentResultFile(alignmentResultsFile, weighting=None, lo
             # image = (ifft(complexRealMult(fft(image), w_func)) / (image.size_x() * image.size_y() * image.size_z()))
             image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
         elif (weighting != None) and (weighting > 0):
-            weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tiltAngle, imdim, imdim, sliceWidth))
+            weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
             image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
 
         thetaStack[ii] = float(round(projection.getTiltAngle() - angle_specimen))

--- a/pytom/reconstruction/reconstructionStructures.py
+++ b/pytom/reconstruction/reconstructionStructures.py
@@ -187,7 +187,7 @@ class Projection(PyTomClass):
     """
     Projection: 
     """
-    def __init__(self, filename=None, tiltAngle=None, offsetX=0, offsetY=0, alignmentTransX=0.,
+    def __init__(self, filename=None, tilt_angle=None, offsetX=0, offsetY=0, alignmentTransX=0.,
                  alignmentTransY=0., alignmentRotation=0., alignmentMagnification=1.,
                  alignmentAxisAngle=0., operationOrder=[2, 0, 1], index=0):
         """
@@ -195,8 +195,8 @@ class Projection(PyTomClass):
 
         @param filename: The filename
         @type filename: string
-        @param tiltAngle: Tilt angle of a projection, rotation around microscope y-axis
-        @type tiltAngle: float
+        @param tilt_angle: Tilt angle of a projection, rotation around microscope y-axis
+        @type tilt_angle: float
         @param offsetX: offset X is used for subtomogram reconstruction from cut out projections
         @type offsetX: float
         @param offsetY: offset Y is used for subtomogram reconstruction from cut out projections
@@ -224,10 +224,10 @@ class Projection(PyTomClass):
         self._xSize = None
         self._ySize = None
 
-        if filename and tiltAngle is None:
+        if filename and tilt_angle is None:
             self._loadTiltAngle()
         else:
-            self._tiltAngle = float(tiltAngle)
+            self._tilt_angle = float(tilt_angle)
 
         self._index = int(index)
         self._offsetX = float(offsetX)
@@ -248,7 +248,7 @@ class Projection(PyTomClass):
     def info(self):
         tline = (" %3d: " %self.getIndex())
         tline = tline + ("Filename: %20s" %self._filename)
-        tline = tline + (", TiltAngle= %6.2f" %self._tiltAngle)
+        tline = tline + (", TiltAngle= %6.2f" %self._tilt_angle)
         return tline
         
     def _loadTiltAngle(self):
@@ -262,14 +262,14 @@ class Projection(PyTomClass):
             if self._filename.split('.')[-1] == 'em':
                 fh = open(self._filename,'rb')
                 fh.seek(168)
-                self._tiltAngle = float(struct.unpack('i',fh.read(4))[0])/1000
+                self._tilt_angle = float(struct.unpack('i',fh.read(4))[0])/1000
                 fh.close()
             else:
                 fh = read_mrc_header(self._filename)
-                self._tiltAngle = fh['user'][0]/1000.  # TODO find correct location of the tiltangle and autowrite it.
+                self._tilt_angle = fh['user'][0]/1000.  # TODO find correct location of the tiltangle and autowrite it.
         except:
             print(f'could not read tilt angle for projection {self._filename}')
-            self._tiltAngle = None
+            self._tilt_angle = None
 
     def _checkValidFile(self):
         """
@@ -299,7 +299,7 @@ class Projection(PyTomClass):
         return self._filename
         
     def getTiltAngle(self):
-        return self._tiltAngle
+        return self._tilt_angle
 
     def getOffsetX(self):
         return self._offsetX
@@ -381,14 +381,14 @@ class Projection(PyTomClass):
         self._filename = filename
         self._checkValidFile()
 
-    def setTiltAngle(self, tiltAngle):
+    def setTiltAngle(self, tilt_angle):
         """
         set tilt angle in projection
 
-        @param tiltAngle: tilt angle (deg)
-        @type tiltAngle: float
+        @param tilt_angle: tilt angle (deg)
+        @type tilt_angle: float
         """
-        self._tiltAngle = float(tiltAngle)
+        self._tilt_angle = float(tilt_angle)
 
     def setOffsetX(self, offsetX):
         """
@@ -510,7 +510,7 @@ class Projection(PyTomClass):
         """
         from lxml import etree
         projection_element = etree.Element('Projection', Filename=str(self._filename),
-                                           TiltAngle=str(float(self._tiltAngle)),OffsetX=str(float(self._offsetX)),
+                                           TiltAngle=str(float(self._tilt_angle)),OffsetX=str(float(self._offsetX)),
                                            OffsetY=str(float(self._offsetY)),
                                            AlignmentTransX=str(float(self._alignmentTransX)),
                                            AlignmentTransY=str(float(self._alignmentTransY)),
@@ -536,7 +536,7 @@ class Projection(PyTomClass):
         
         self._filename = projection_element.get('Filename')
         self._checkValidFile()
-        self._tiltAngle = float(projection_element.get('TiltAngle'))
+        self._tilt_angle = float(projection_element.get('TiltAngle'))
         self._offsetX = float(projection_element.get('OffsetX'))
         self._offsetY = float(projection_element.get('OffsetY'))
         self._alignmentMagnification = float(projection_element.get('AlignmentMagnification'))
@@ -608,7 +608,7 @@ class ProjectionList(PyTomClass):
                 metafile = os.path.join(directory, possible_files[0])
         if metafile is not None:  # if we have a metafile, load its tilt angles
             metadata = loadstar(metafile, dtype=DATATYPE_METAFILE)
-            tiltAngles = metadata['TiltAngle']
+            tilt_angles = metadata['TiltAngle']
 
         files = [line for line in sorted(os.listdir(directory)) if prefix in line]
 
@@ -618,7 +618,7 @@ class ProjectionList(PyTomClass):
             if os.path.splitext(file)[1] in ['.em', '.mrc']:
                 i = int(file.split('_')[-1].split('.')[0])  # TODO this is hackish => but leave it for now
                 if metafile is not None:
-                    projection = Projection(filename=os.path.join(directory, file), tiltAngle=tiltAngles[i], index=i)
+                    projection = Projection(filename=os.path.join(directory, file), tilt_angle=tilt_angles[i], index=i)
                 else:
                     projection = Projection(filename=os.path.join(directory, file), index=i)
                 self.append(projection)
@@ -656,7 +656,7 @@ class ProjectionList(PyTomClass):
             for i in range(len(alignment_results)):
                 # set offsetx and offsety ??
                 projection = Projection(filename=alignment_results[i]['FileName'],
-                                        tiltAngle=alignment_results[i]['TiltAngle'],
+                                        tilt_angle=alignment_results[i]['TiltAngle'],
                                         alignmentTransX=alignment_results[i]['AlignmentTransX'],
                                         alignmentTransY=alignment_results[i]['AlignmentTransY'],
                                         alignmentRotation=alignment_results[i]['InPlaneRotation'],
@@ -712,7 +712,7 @@ class ProjectionList(PyTomClass):
 
         projectionList_element = etree.Element('ProjectionList')
 
-        ##self._list = sorted(self._list, key=lambda Projection: Projection._tiltAngle)
+        ##self._list = sorted(self._list, key=lambda Projection: Projection._tilt_angle)
 
         for projection in self._list:
             projectionList_element.append(projection.toXML())
@@ -1991,8 +1991,8 @@ class ProjectionList(PyTomClass):
         @type binning: int
         @param applyWeighting: applyWeighting
         @type applyWeighting: bool
-        @param tiltAngle: optional tiltAngle of image
-        @type tiltAngle: float
+        @param tilt_angle: optional tilt_angle of image
+        @type tilt_angle: float
         @param showProgressBar: show pretty bar
         @type showProgressBar: bool
         @param verbose: talkative
@@ -2065,7 +2065,7 @@ class ProjectionList(PyTomClass):
         self.tilt_angles = []  # TODO is this also not already initiated at the class init?
 
         for ii, projection in enumerate(self._list):
-            self.tilt_angles.append(projection._tiltAngle)  # TODO are these correctly assigned????
+            self.tilt_angles.append(projection._tilt_angle)  # TODO are these correctly assigned????
 
         self.tilt_angles = sorted(self.tilt_angles)  # they need to be sorted, and the specific angle is got later
 
@@ -2095,7 +2095,7 @@ class ProjectionList(PyTomClass):
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
             elif weighting == 1:  # exact filter
                 print('weighting == 1, exact filter, needs tilt angle infomration, currently not provided')
-                weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tiltAngle,
+                weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tilt_angle,
                                                              imdim, imdim, slice_width))
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
@@ -2214,7 +2214,7 @@ class ProjectionList(PyTomClass):
             aty = alignmentResults['AlignmentTransY'][n]
             rot = alignmentResults['InPlaneRotation'][n]
             mag = alignmentResults['Magnification'][n]
-            projection = Projection(imageList[n], tiltAngle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
+            projection = Projection(imageList[n], tilt_angle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
                                     alignmentRotation=rot, alignmentMagnification=mag)
             projectionList.append(projection)
 
@@ -2242,7 +2242,7 @@ class ProjectionList(PyTomClass):
                 # image = rotate(image,180.,0.,0.)
                 image = resize(volume=image, factor=1 / float(binning))[0]
 
-            tiltAngle = projection._tiltAngle
+            tilt_angle = projection._tilt_angle
 
             # normalize to contrast - subtract mean and norm to mean
             immean = mean(image)
@@ -2286,7 +2286,7 @@ class ProjectionList(PyTomClass):
             if weighting == -1:  # ramp filter
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
             elif weighting == 1:  # exact filter
-                weightSlice = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
+                weightSlice = fourierFilterShift(exactFilter(tilt_angles, tilt_angle, imdim, imdim, slice_width))
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
             thetaStack(int(round(projection.getTiltAngle()))-self.angle_specimen, 0, 0, ii)
@@ -2370,7 +2370,7 @@ class ProjectionList(PyTomClass):
             aty = alignmentResults['AlignmentTransY'][n]
             rot = alignmentResults['InPlaneRotation'][n]
             mag = alignmentResults['Magnification'][n]
-            projection = Projection(imageList[n], tiltAngle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
+            projection = Projection(imageList[n], tilt_angle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
                                     alignmentRotation=rot, alignmentMagnification=mag)
             projectionList.append(projection)
 
@@ -2404,7 +2404,7 @@ class ProjectionList(PyTomClass):
             else:
                 order =[2,1,0]
 
-            args = (projection._filename, projection._index, projection._tiltAngle, tilt_angles, slice_width,
+            args = (projection._filename, projection._index, projection._tilt_angle, tilt_angles, slice_width,
                     projection._alignmentTransX, projection._alignmentTransY, projection._alignmentRotation,
                     projection._alignmentMagnification, order,
                     scaleFactorParticle, weighting, imdim, imdimX, imdimY, binning, lowpassFilter, circleFilter,
@@ -2428,7 +2428,7 @@ class ProjectionList(PyTomClass):
 
         return [stack, phiStack, thetaStack, offsetStack]
 
-    def align_single_image(self, filename, index, tiltAngle, tilt_angles, slice_width, alignmentTransX, alignmentTransY,
+    def align_single_image(self, filename, index, tilt_angle, tilt_angles, slice_width, alignmentTransX, alignmentTransY,
                            alignmentRotation, alignmentMagnification, order,
                            scaleFactorParticle, weighting, imdim, imdimX, imdimY, binning, lowpassFilter, circleFilter,
                            fname):
@@ -2438,8 +2438,8 @@ class ProjectionList(PyTomClass):
            @type fname: str
            @param index: index of image
            @type index: int
-           @param tiltAngle: tilt angle of tilt image
-           @type tiltAngle: float
+           @param tilt_angle: tilt angle of tilt image
+           @type tilt_angle: float
            @param tilt_angles: all angles of tiltseries
            @type tilt_angles: numpy.ndarray or list
            @param slice_width: width of a slice in fourier space
@@ -2523,7 +2523,7 @@ class ProjectionList(PyTomClass):
             # image = rotate(image,180.,0.,0.)
             image = resize(volume=image, factor=1 / float(binning))[0]
 
-        tiltAngle = tiltAngle
+        tilt_angle = tilt_angle
 
         # normalize to contrast - subtract mean and norm to mean
         immean = vol2npy(image).mean()
@@ -2563,7 +2563,7 @@ class ProjectionList(PyTomClass):
             image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
         elif (weighting != None) and (weighting > 0):
-            weightSlice = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
+            weightSlice = fourierFilterShift(exactFilter(tilt_angles, tilt_angle, imdim, imdim, slice_width))
             image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
         image.write(fname)
@@ -2581,8 +2581,8 @@ class ProjectionList(PyTomClass):
         @type binning: int
         @param applyWeighting: applyWeighting
         @type applyWeighting: bool
-        @param tiltAngle: optional tiltAngle of image
-        @type tiltAngle: float
+        @param tilt_angle: optional tilt_angle of image
+        @type tilt_angle: float
         @param showProgressBar: show pretty bar
         @type showProgressBar: bool
         @param verbose: talkative
@@ -2633,7 +2633,7 @@ class ProjectionList(PyTomClass):
         self.tilt_angles = []
 
         for (i, projection) in enumerate(self._list):
-            self.tilt_angles.append(projection._tiltAngle)
+            self.tilt_angles.append(projection._tilt_angle)
 
         self.tilt_angles = sorted(self.tilt_angles)
 
@@ -2645,11 +2645,11 @@ class ProjectionList(PyTomClass):
             if int((applyWeighting)) >= 1:
 
                 if int(applyWeighting) != 2:
-                    weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tiltAngle,
+                    weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tilt_angle,
                                                                  imdim, imdim, imdim))
 
                 else:
-                    weightSlice = fourierFilterShift(rotateFilter(self.tilt_angles, projection._tiltAngle,
+                    weightSlice = fourierFilterShift(rotateFilter(self.tilt_angles, projection._tilt_angle,
                                                                   imdim, imdim, imdim))
 
             image = read(projection.getFilename(), 0, 0, 0, 0, 0, 0, 0, 0, 0, binning, binning, 1)
@@ -2723,7 +2723,7 @@ class ProjectionList(PyTomClass):
             aty = alignmentResults['AlignmentTransY'][n]
             rot = alignmentResults['InPlaneRotation'][n]
             mag = 1 / (alignmentResults['Magnification'][n])
-            projection = Projection(imageList[n], tiltAngle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
+            projection = Projection(imageList[n], tilt_angle=tilt_angles[n], alignmentTransX=atx, alignmentTransY=aty,
                                     alignmentRotation=rot, alignmentMagnification=mag)
             projectionList.append(projection)
 
@@ -2739,7 +2739,7 @@ class ProjectionList(PyTomClass):
             if binning > 1:
                 image = resize(image, 1 / binning)
 
-            tiltAngle = projection._tiltAngle
+            tilt_angle = projection._tilt_angle
 
             # 1 -- normalize to contrast - subtract mean and norm to mean
             immean = image.mean()
@@ -2794,7 +2794,7 @@ class ProjectionList(PyTomClass):
                 # image = (ifft(complexRealMult(fft(image), w_func)) / (image.size_x() * image.size_y() * image.size_z()))
                 image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
             elif (weighting != None) and (weighting > 0):
-                weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
+                weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tilt_angle, imdim, imdim, slice_width))
                 image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
 
             thetaStack[ii] = float(round(projection.getTiltAngle() - angle_specimen))
@@ -2818,9 +2818,9 @@ class ProjectionList(PyTomClass):
             print(i * num_procs + pid)
 
             if int(applyWeighting) >= 1:
-                print(self.tilt_angles, projection._tiltAngle, imgDim)
+                print(self.tilt_angles, projection._tilt_angle, imgDim)
 
-                self.temp_weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tiltAngle,
+                self.temp_weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tilt_angle,
                                                                        imgDim, imgDim, imgDim))
 
             image = read(projection.getFilename(), 0, 0, 0, 0, 0, 0, 0, 0, 0, binning, binning, 1)

--- a/pytom/reconstruction/reconstructionStructures.py
+++ b/pytom/reconstruction/reconstructionStructures.py
@@ -158,7 +158,7 @@ def align_single_projection(index, projection_list, tilt_angles, shared_dtype, s
                                     crop=True, center=center)
 
     if low_pass_freq > 0:
-        filtered = filter(volume=image, filterObject=lpf, fourierOnly=False)
+        filtered = filter(volume=image, filterObject=lpf, fourier_only=False)
         image = filtered[0]
 
     # smoothen once more to avoid edges
@@ -1646,7 +1646,7 @@ class ProjectionList(PyTomClass):
                                             crop=True, center=center)
 
             if low_pass_freq > 0:
-                filtered = filter(volume=image, filterObject=lpf, fourierOnly=False)
+                filtered = filter(volume=image, filterObject=lpf, fourier_only=False)
                 image = filtered[0]
 
             # smoothen once more to avoid edges
@@ -2087,7 +2087,7 @@ class ProjectionList(PyTomClass):
                 image = newImage
 
             if low_pass_freq > 0:
-                filtered = filter(volume=image, filterObject=lpf, fourierOnly=False)
+                filtered = filter(volume=image, filterObject=lpf, fourier_only=False)
                 image = filtered[0]
 
             # weighting
@@ -2276,7 +2276,7 @@ class ProjectionList(PyTomClass):
                                         center=center)
 
             if low_pass_freq > 0:
-                filtered = filter(volume=image, filterObject=lpf, fourierOnly=False)
+                filtered = filter(volume=image, filterObject=lpf, fourier_only=False)
                 image = filtered[0]
 
             # smoothen once more to avoid edges
@@ -2552,7 +2552,7 @@ class ProjectionList(PyTomClass):
         image = general_transform2d(v=image, rot=rot, shift=[transX, transY], scale=mag, order=order, crop=True, center=center)
 
         if lowpassFilter:
-            filtered = filterFunction(volume=image, filterObject=lpf, fourierOnly=False)
+            filtered = filterFunction(volume=image, filterObject=lpf, fourier_only=False)
             image = filtered[0]
 
         # smoothen once more to avoid edges

--- a/pytom/reconstruction/reconstructionStructures.py
+++ b/pytom/reconstruction/reconstructionStructures.py
@@ -2037,7 +2037,7 @@ class ProjectionList(PyTomClass):
         offsetStack.setAll(0.0)
 
         # design filters
-        sliceWidth = imdim  # this should be relative to the particle size as that determines the crowther freq
+        slice_width = imdim  # this should be relative to the particle size as that determines the crowther freq
 
         if weighting == -1:
             weightSlice = fourierFilterShift(rampFilter(imdim, imdim))
@@ -2096,7 +2096,7 @@ class ProjectionList(PyTomClass):
             elif weighting == 1:  # exact filter
                 print('weighting == 1, exact filter, needs tilt angle infomration, currently not provided')
                 weightSlice = fourierFilterShift(exactFilter(self.tilt_angles, projection._tiltAngle,
-                                                             imdim, imdim, sliceWidth))
+                                                             imdim, imdim, slice_width))
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
             thetaStack(int(round(projection.getTiltAngle() - angle_specimen)), 0, 0, ii)
@@ -2186,7 +2186,7 @@ class ProjectionList(PyTomClass):
         offsetStack.setAll(0.0)
 
         # design filters
-        sliceWidth = imdim  # this should be relative to the particle size as that determines the crowther freq
+        slice_width = imdim  # this should be relative to the particle size as that determines the crowther freq
 
         # pre-determine analytical weighting function and lowpass for speedup
         if weighting == -1:
@@ -2286,7 +2286,7 @@ class ProjectionList(PyTomClass):
             if weighting == -1:  # ramp filter
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
             elif weighting == 1:  # exact filter
-                weightSlice = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, sliceWidth))
+                weightSlice = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
                 image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
             thetaStack(int(round(projection.getTiltAngle()))-self.angle_specimen, 0, 0, ii)
@@ -2362,7 +2362,7 @@ class ProjectionList(PyTomClass):
         else:
             imdim = imdim
 
-        sliceWidth = imdim
+        slice_width = imdim
 
         projectionList = ProjectionList()
         for n, image in enumerate(imageList):
@@ -2404,7 +2404,7 @@ class ProjectionList(PyTomClass):
             else:
                 order =[2,1,0]
 
-            args = (projection._filename, projection._index, projection._tiltAngle, tilt_angles, sliceWidth,
+            args = (projection._filename, projection._index, projection._tiltAngle, tilt_angles, slice_width,
                     projection._alignmentTransX, projection._alignmentTransY, projection._alignmentRotation,
                     projection._alignmentMagnification, order,
                     scaleFactorParticle, weighting, imdim, imdimX, imdimY, binning, lowpassFilter, circleFilter,
@@ -2428,7 +2428,7 @@ class ProjectionList(PyTomClass):
 
         return [stack, phiStack, thetaStack, offsetStack]
 
-    def align_single_image(self, filename, index, tiltAngle, tilt_angles, sliceWidth, alignmentTransX, alignmentTransY,
+    def align_single_image(self, filename, index, tiltAngle, tilt_angles, slice_width, alignmentTransX, alignmentTransY,
                            alignmentRotation, alignmentMagnification, order,
                            scaleFactorParticle, weighting, imdim, imdimX, imdimY, binning, lowpassFilter, circleFilter,
                            fname):
@@ -2442,8 +2442,8 @@ class ProjectionList(PyTomClass):
            @type tiltAngle: float
            @param tilt_angles: all angles of tiltseries
            @type tilt_angles: numpy.ndarray or list
-           @param sliceWidth: width of a slice in fourier space
-           @type sliceWidth: int
+           @param slice_width: width of a slice in fourier space
+           @type slice_width: int
            @param alignmentTransX: translation of tilt image in x-direction
            @type alignmentTransX: float
            @param alignmentTransY: translation of tilt image in y-direction
@@ -2563,7 +2563,7 @@ class ProjectionList(PyTomClass):
             image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
         elif (weighting != None) and (weighting > 0):
-            weightSlice = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, sliceWidth))
+            weightSlice = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
             image = ifft(complexRealMult(complexRealMult(fft(image), weightSlice), circleSlice), scaling=True)
 
         image.write(fname)
@@ -2696,7 +2696,7 @@ class ProjectionList(PyTomClass):
             imdimY = int(float(imdimY) / float(binning) + .5)
 
         imdim = max(imdimY, imdimX)
-        sliceWidth = imdim
+        slice_width = imdim
 
         if (weighting != None) and (float(weighting) < -0.001):
             cfreq = abs(tilt_angles[1:] - tilt_angles[:-1])
@@ -2794,7 +2794,7 @@ class ProjectionList(PyTomClass):
                 # image = (ifft(complexRealMult(fft(image), w_func)) / (image.size_x() * image.size_y() * image.size_z()))
                 image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
             elif (weighting != None) and (weighting > 0):
-                weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tiltAngle, imdim, imdim, sliceWidth))
+                weightSlice = xp.fft.fftshift(exact_filter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
                 image = xp.fft.ifftn(xp.fft.fftn(image) * weightSlice * circleSlice).real
 
             thetaStack[ii] = float(round(projection.getTiltAngle() - angle_specimen))

--- a/pytom/reconstruction/tiltAlignmentFunctions.py
+++ b/pytom/reconstruction/tiltAlignmentFunctions.py
@@ -765,19 +765,19 @@ def alignmentFixMagRot( Markers_, cTilt, sTilt, ireftilt, irefmark=1, r=None, im
     return(psiindeg, shiftX, shiftY, x, y, z, distLine, diffX, diffY, shiftVarX, shiftVarY)
 
 
-def simulate_markers(markCoords, tiltAngles, tiltAxis=-76.71, ireftilt=None,
+def simulate_markers(markCoords, tilt_angles, tiltAxis=-76.71, ireftilt=None,
         ampTrans=100., ampRot=.5, ampMag=.01, dBeam=None, dMagnFocus=None):
     """
     simulate marker coordinates for testing alignment routines
 
     (Markers, TiltSeries, TiltAlignmentParas) = simulate_markers(markCoords, \
-    tiltAngles, tiltAxis=-76.71, ireftilt=None,\
+    tilt_angles, tiltAxis=-76.71, ireftilt=None,\
     ampTrans=100., ampRot=.5, ampMag=.01, dBeam=None)
 
     @param markCoords: marker coordinates
     @type markCoords: array
-    @param tiltAngles: tilt angles
-    @type tiltAngles: array
+    @param tilt_angles: tilt angles
+    @type tilt_angles: array
     @param tiltAxis: approximate tilt axis
     @type tiltAxis: float
     @param ampTrans: amplitude of translation distortions (gaussian)
@@ -805,7 +805,7 @@ def simulate_markers(markCoords, tiltAngles, tiltAxis=-76.71, ireftilt=None,
         cdbeam = cos(dBeam*pi/180.)
         sdbeam = sin(dBeam*pi/180.)
 
-    ntilt = len(tiltAngles)
+    ntilt = len(tilt_angles)
     rot = ntilt*[tiltAxis]
     srot = ntilt*[0.]
     crot = ntilt*[1.]
@@ -816,7 +816,7 @@ def simulate_markers(markCoords, tiltAngles, tiltAxis=-76.71, ireftilt=None,
     sTilt = ntilt*[0.]
 
     if not ireftilt:
-        ireftilt = tiltAngles.argmin()+1
+        ireftilt = tilt_angles.argmin()+1
     #generate Markers
     nmarks = len(markCoords)
     Markers = []
@@ -843,7 +843,7 @@ def simulate_markers(markCoords, tiltAngles, tiltAxis=-76.71, ireftilt=None,
     TiltSeries.createEmptyProjections()
 
     #compute 'alignment'
-    for (itilt, tiltAngle) in enumerate(tiltAngles):
+    for (itilt, tilt_angle) in enumerate(tilt_angles):
         rot[itilt] = tiltAxis + gauss(0.,ampRot)
     crot[itilt] = cos(rot[itilt]/180.*pi + pi/2.)
     srot[itilt] = sin(rot[itilt]/180.*pi + pi/2.)
@@ -856,9 +856,9 @@ def simulate_markers(markCoords, tiltAngles, tiltAxis=-76.71, ireftilt=None,
         transX[itilt] = gauss(0., ampTrans)
         transY[itilt] = gauss(0., ampTrans)
 
-    cTilt[itilt] = cos(tiltAngle/180.*pi)
-    sTilt[itilt] = sin(tiltAngle/180.*pi)
-    TiltSeries._ProjectionList[itilt].setTiltAngle( tiltAngle)
+    cTilt[itilt] = cos(tilt_angle/180.*pi)
+    sTilt[itilt] = sin(tilt_angle/180.*pi)
+    TiltSeries._ProjectionList[itilt].setTiltAngle( tilt_angle)
     TiltSeries._ProjectionList[itilt].setAlignmentTransX(transX[itilt])
     TiltSeries._ProjectionList[itilt].setAlignmentTransY(transY[itilt])
     TiltSeries._ProjectionList[itilt].setAlignmentRotation(rot[itilt])
@@ -875,7 +875,7 @@ def simulate_markers(markCoords, tiltAngles, tiltAxis=-76.71, ireftilt=None,
         [xmod, ymod] = rotate_vector2d(markCoord, cpsi, spsi)
 
         # simulate corresponding marker positions in projs
-        for (itilt, tiltAngle) in enumerate(tiltAngles):
+        for (itilt, tilt_angle) in enumerate(tilt_angles):
             # model projection
             ## beam inclination
             if dBeam:
@@ -1007,7 +1007,7 @@ def readIMODmarkerfile(markerfile, binning=1):
             marker.set_yProj( iproj=int(float(tmp[3])), yProj=float(tmp[2]) * scalefac)
     return markers
 
-def readIMODtiltAngles(tltfile):
+def readIMODtilt_angles(tltfile):
     """
     read tilt angles from IMOD file
 

--- a/pytom/reconstruction/writeAlignedProjections.py
+++ b/pytom/reconstruction/writeAlignedProjections.py
@@ -57,7 +57,7 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
         # lpf2 = pytom_freqweight.weight(0.0, lowpassFilter * imdimY / 2, imdimX, imdimY // 2 + 1, 1,
         #                               lowpassFilter / 5. * imdimY)
         #lpf = bandpassFilter(volume=vol(imdim, imdim,1),lowestFrequency=0,highestFrequency=int(lowpassFilter*imdim/2),
-        #                     bpf=None,smooth=lowpassFilter/5.*imdim,fourierOnly=False)[1]
+        #                     bpf=None,smooth=lowpassFilter/5.*imdim,fourier_only=False)[1]
 
     tilt_angles = []
 
@@ -112,7 +112,7 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
 
             # # 5 -- Optional Low Pass Filter
             # if lowpassFilter:
-            #     filtered = filterFunction( volume=image, filterObject=lpf2, fourierOnly=False)
+            #     filtered = filterFunction( volume=image, filterObject=lpf2, fourier_only=False)
             #     image = filtered[0]
 
             # 1 -- normalize to contrast - subtract mean and norm to mean
@@ -153,7 +153,7 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
 
             # 5 -- Optional Low Pass Filter
             if lowpassFilter:
-                filtered = filterFunction( volume=image, filterObject=lpf, fourierOnly=False)
+                filtered = filterFunction( volume=image, filterObject=lpf, fourier_only=False)
                 image = filtered[0]
 
             # 6 -- smoothen once more to avoid edges

--- a/pytom/reconstruction/writeAlignedProjections.py
+++ b/pytom/reconstruction/writeAlignedProjections.py
@@ -41,7 +41,7 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
 
     imdim = int(max(imdimX, imdimY))
 
-    sliceWidth = imdim
+    slice_width = imdim
 
     # pre-determine analytical weighting function and lowpass for speedup
     if (weighting != None) and (weighting < -0.001):
@@ -164,9 +164,9 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
                 image = (ifft( complexRealMult( fft( image), w_func) ) / (image.size_x()*image.size_y()*image.size_z()) )
             elif (weighting != None) and (weighting > 0):
                 if weighting > 1.5:
-                    w_func = fourierFilterShift(rotateFilter(tilt_angles, tiltAngle, imdim, imdim, sliceWidth))
+                    w_func = fourierFilterShift(rotateFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
                 else:
-                    w_func = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, sliceWidth))
+                    w_func = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
 
                 image = (ifft( complexRealMult( fft( image), w_func) )/
                       (image.size_x()*image.size_y()*image.size_z()) )

--- a/pytom/reconstruction/writeAlignedProjections.py
+++ b/pytom/reconstruction/writeAlignedProjections.py
@@ -62,7 +62,7 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
     tilt_angles = []
 
     for projection in TiltSeries_._ProjectionList:
-        tilt_angles.append( projection._tiltAngle )
+        tilt_angles.append( projection._tilt_angle )
     tilt_angles = sorted(tilt_angles)
 
     #q = np.matrix(abs(np.arange(-imdim//2, imdim//2)))
@@ -107,8 +107,8 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
                     header.set_dim(x=imdim, y=imdim, z=1)
 
 
-            tiltAngle = projection._tiltAngle
-            header.set_tiltangle(tiltAngle)
+            tilt_angle = projection._tilt_angle
+            header.set_tiltangle(tilt_angle)
 
             # # 5 -- Optional Low Pass Filter
             # if lowpassFilter:
@@ -132,7 +132,7 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
                                +'.'+TiltSeries_._tiltSeriesFormat)
             if verbose:
                 tline = ("%30s" %newFilename)
-                tline = tline + (" (tiltAngle=%6.2f)" % tiltAngle)
+                tline = tline + (" (tiltAngle=%6.2f)" % tilt_angle)
                 tline = tline + (": transX=%6.1f" %transX)
                 tline = tline + (", transY=%6.1f" %transY)
                 tline = tline + (", rot=%6.2f" %rot)
@@ -164,9 +164,9 @@ def writeAlignedProjections(TiltSeries_, weighting=None,
                 image = (ifft( complexRealMult( fft( image), w_func) ) / (image.size_x()*image.size_y()*image.size_z()) )
             elif (weighting != None) and (weighting > 0):
                 if weighting > 1.5:
-                    w_func = fourierFilterShift(rotateFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
+                    w_func = fourierFilterShift(rotateFilter(tilt_angles, tilt_angle, imdim, imdim, slice_width))
                 else:
-                    w_func = fourierFilterShift(exactFilter(tilt_angles, tiltAngle, imdim, imdim, slice_width))
+                    w_func = fourierFilterShift(exactFilter(tilt_angles, tilt_angle, imdim, imdim, slice_width))
 
                 image = (ifft( complexRealMult( fft( image), w_func) )/
                       (image.size_x()*image.size_y()*image.size_z()) )

--- a/pytom/simulation/simulateProjections.py
+++ b/pytom/simulation/simulateProjections.py
@@ -704,7 +704,7 @@ def reconstruct_tomogram(prefix, suffix, start_idx, end_idx, volsize, angles, ou
     projections = ProjectionList()
 
     for i in range(start_idx, end_idx + 1):
-        p = Projection(prefix + str(i) + suffix, tiltAngle=angles[i - 1])
+        p = Projection(prefix + str(i) + suffix, tilt_angle=angles[i - 1])
         projections.append(p)
 
     outputname = os.path.join(outputFolder, f'tomogram_model_{modelID}.em')

--- a/pytom/simulation/support.py
+++ b/pytom/simulation/support.py
@@ -66,8 +66,8 @@ def reduce_resolution_fourier(input, spacing, resolution):
     """
     gaussian_filter = create_gaussian_low_pass(input.shape, spacing, resolution)
     if 'gpu' in device:
-        from pytom.agnostic.filter import applyFourierFilterFull
-        return applyFourierFilterFull(input, xp.fft.ifftshift(gaussian_filter))
+        from pytom.agnostic.filter import apply_fourier_filter_full
+        return apply_fourier_filter_full(input, xp.fft.ifftshift(gaussian_filter))
     else:
         from pytom.agnostic.transform import fourier_filter
         return fourier_filter(input, gaussian_filter, human=True)

--- a/pytom/simulation/template.py
+++ b/pytom/simulation/template.py
@@ -65,7 +65,7 @@ def generate_template_from_pdb(structure_file_path, spacing, binning=1, modify_s
     import os
     from pytom.simulation.microscope import create_ctf, display_microscope_function
     from pytom.agnostic.transform import resize
-    from pytom.agnostic.filter import applyFourierFilterFull
+    from pytom.agnostic.filter import apply_fourier_filter_full
     from pytom.agnostic.tools import paste_in_center
     from pytom.simulation.support import create_gaussian_low_pass
     from pytom.simulation.potential import iasa_integration_parallel, iasa_integration_gpu, call_chimera
@@ -136,7 +136,7 @@ def generate_template_from_pdb(structure_file_path, spacing, binning=1, modify_s
             print('Skipping plotting due to error.')
 
     # filter the template
-    template = applyFourierFilterFull(template, xp.fft.ifftshift(filter))
+    template = apply_fourier_filter_full(template, xp.fft.ifftshift(filter))
 
     # binning
     if binning > 1:
@@ -152,7 +152,7 @@ def generate_template_from_map(map_file_path, spacing, original_spacing=None, bi
     from pytom.agnostic.io import read, read_pixelsize
     from pytom.simulation.microscope import create_ctf, display_microscope_function
     from pytom.agnostic.transform import resize
-    from pytom.agnostic.filter import applyFourierFilterFull
+    from pytom.agnostic.filter import apply_fourier_filter_full
     from pytom.agnostic.tools import paste_in_center
     from pytom.simulation.support import create_gaussian_low_pass
 
@@ -206,7 +206,7 @@ def generate_template_from_map(map_file_path, spacing, original_spacing=None, bi
             print('Skipping plotting due to error.')
 
     # filter the template
-    template = applyFourierFilterFull(template, xp.fft.ifftshift(filter))
+    template = apply_fourier_filter_full(template, xp.fft.ifftshift(filter))
 
     # binning
     if binning > 1:

--- a/tests/E2ETests/helper_functions.py
+++ b/tests/E2ETests/helper_functions.py
@@ -85,7 +85,7 @@ def cleanUp_RandomParticleList( pl_filename='pl.xml', pdir='./testparticles'):
     rmdir(pdir)
     remove(pl_filename)
 
-def create_TiltSeries(data, tiltAngles, outputfolder='./'):
+def create_TiltSeries(data, tilt_angles, outputfolder='./'):
     from pytom.agnostic.io import read, write
     from pytom.agnostic.transform import rotate_axis
     import os
@@ -95,6 +95,6 @@ def create_TiltSeries(data, tiltAngles, outputfolder='./'):
 
     if not os.path.exists(outputfolder): os.mkdir(outputfolder)
 
-    for n, tiltAngle in enumerate(tiltAngles):
+    for n, tilt_angle in enumerate(tilt_angles):
         outname = os.path.join(outputfolder, 'sorted_{:03d}.mrc'.format(n))
-        write(outname, rotate_axis(data, tiltAngle, axis='y').sum(axis=2),tilt_angle=tiltAngle)
+        write(outname, rotate_axis(data, tilt_angle, axis='y').sum(axis=2),tilt_angle=tilt_angle)

--- a/tests/E2ETests/helper_functions.py
+++ b/tests/E2ETests/helper_functions.py
@@ -33,7 +33,7 @@ def create_RandomParticleList( reffile, pl_filename='pl.xml', pdir='./testpartic
     a = 0
 
 
-    wedge = Wedge(wedge_angles=[30.0,30.0], cutoffRadius=50.0)
+    wedge = Wedge(wedge_angles=[30.0,30.0], cutoff_radius=50.0)
 
     pl = ParticleList( directory='./')
     ref1 = read(reffile)

--- a/tests/E2ETests/test_pytomvolume_vs_numpy.py
+++ b/tests/E2ETests/test_pytomvolume_vs_numpy.py
@@ -57,7 +57,7 @@ class NumericalTest(unittest.TestCase):
     def wedgePyTomVol(self):
         from pytom.basic.structures import Wedge
         from pytom.lib.pytom_numpy import vol2npy
-        w = Wedge(wedge_angles=self.wedge_angles, cutoffRadius=self.cutoff)
+        w = Wedge(wedge_angles=self.wedge_angles, cutoff_radius=self.cutoff)
         wedge = w.return_wedge_volume(*self.dims)
         wedge_np = vol2npy(wedge).copy()
         return xp.array(wedge_np, dtype=xp.float32)

--- a/tests/E2ETests/test_pytomvolume_vs_numpy.py
+++ b/tests/E2ETests/test_pytomvolume_vs_numpy.py
@@ -58,7 +58,7 @@ class NumericalTest(unittest.TestCase):
         from pytom.basic.structures import Wedge
         from pytom.lib.pytom_numpy import vol2npy
         w = Wedge(wedge_angles=self.wedge_angles, cutoffRadius=self.cutoff)
-        wedge = w.returnWedgeVolume(*self.dims)
+        wedge = w.return_wedge_volume(*self.dims)
         wedge_np = vol2npy(wedge).copy()
         return xp.array(wedge_np, dtype=xp.float32)
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -88,7 +88,7 @@ def cleanUp_RandomParticleList( pl_filename='pl.xml', pdir='./testparticles'):
     remove(pl_filename)
 
 
-def create_TiltSeries(data, tiltAngles, outputfolder='./'):
+def create_TiltSeries(data, tilt_angles, outputfolder='./'):
     from pytom.agnostic.io import read, write
     from pytom.agnostic.transform import rotate_axis
     import os
@@ -98,9 +98,9 @@ def create_TiltSeries(data, tiltAngles, outputfolder='./'):
 
     if not os.path.exists(outputfolder): os.mkdir(outputfolder)
 
-    for n, tiltAngle in enumerate(tiltAngles):
+    for n, tilt_angle in enumerate(tilt_angles):
         outname = os.path.join(outputfolder, 'sorted_{:03d}.mrc'.format(n))
-        write(outname, rotate_axis(data, tiltAngle, axis='y').sum(axis=2),tilt_angle=tiltAngle)
+        write(outname, rotate_axis(data, tilt_angle, axis='y').sum(axis=2),tilt_angle=tilt_angle)
 
 
 def remove_tree(foldername):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -34,7 +34,7 @@ def create_RandomParticleList( reffile, pl_filename='pl.xml', pdir='./testpartic
     a = 0
 
 
-    wedge = Wedge(wedge_angles=[30.0,30.0], cutoffRadius=50.0)
+    wedge = Wedge(wedge_angles=[30.0,30.0], cutoff_radius=50.0)
 
     pl = ParticleList( directory='./')
     ref1 = read(reffile)

--- a/tests/test_FilterTest.py
+++ b/tests/test_FilterTest.py
@@ -106,9 +106,9 @@ class pytom_FilterTest(unittest.TestCase):
         refNoise.setV(1., 32, 32, 32)
         # make sure that out of bounds frequency works
         fil1 = bandpassFilter(volume=refNoise, lowestFrequency=0, highestFrequency=30, bpf=None, smooth=1,
-                             fourierOnly=False)
+                             fourier_only=False)
         fil2 = bandpassFilter(volume=refNoise, lowestFrequency=0, highestFrequency=16, bpf=None, smooth=1,
-                             fourierOnly=False)
+                             fourier_only=False)
         #fil1[0].write('fil1.em')
         #fil2[0].write('fil2.em')
         filter = fil1[1]

--- a/tests/test_FilterTest.py
+++ b/tests/test_FilterTest.py
@@ -48,12 +48,12 @@ class pytom_FilterTest(unittest.TestCase):
         rot = Rotation(90.,0.,30.)
         wangle = 30.
 
-        wedgeInfo = Wedge(wedge_angles=wangle, cutoffRadius=0.0, tiltAxis='Y', smooth=3.0)
+        wedgeInfo = Wedge(wedge_angles=wangle, cutoff_radius=0.0, tiltAxis='Y', smooth=3.0)
         tmp = wedgeInfo.apply(v)
         vfil1 = vol(v.size_x(),v.size_y(),v.size_z())
         rotate(tmp, vfil1, rot[0], rot[1], rot[2])
 
-        wedgeInfoRot = Wedge(wedge_angles=wangle, cutoffRadius=0.0,tiltAxis=rot,smooth = 3.0)
+        wedgeInfoRot = Wedge(wedge_angles=wangle, cutoff_radius=0.0,tiltAxis=rot,smooth = 3.0)
         vfil2 = wedgeInfoRot.apply(v)
         #vfil2.write('xxx2.em')
 

--- a/tests/test_FilterTest.py
+++ b/tests/test_FilterTest.py
@@ -19,7 +19,7 @@ class pytom_FilterTest(unittest.TestCase):
         v.setV(1.,16,16,16)
 
         wedgeInfo = WedgeInfo(30.0)#,[10.0,20.0,30.0],0.0)
-        wvol = wedgeInfo.returnWedgeVolume(v.size_x(), v.size_y(), v.size_z())
+        wvol = wedgeInfo.return_wedge_volume(v.size_x(), v.size_y(), v.size_z())
         wfil = wedgeInfo.returnWedgeFilter(v.size_x(), v.size_y(), v.size_z())
         vfil1 = wedgeInfo.apply(v)
         vfil2 = filter(v,wfil)
@@ -57,14 +57,14 @@ class pytom_FilterTest(unittest.TestCase):
         vfil2 = wedgeInfoRot.apply(v)
         #vfil2.write('xxx2.em')
 
-        wrot = wedgeInfo.returnWedgeVolume(v.size_x(), v.size_y(), v.size_z(), False, rot)
+        wrot = wedgeInfo.return_wedge_volume(v.size_x(), v.size_y(), v.size_z(), False, rot)
         fv = fft(v)
         fvol3 = complexRealMult(fv,wrot)
         vfil3 = ifft(fvol3)
         vfil3.shiftscale(0.0,1/float(v.size_x()*v.size_y()*v.size_z()))
         #vfil3.write('xxx3.em')
 
-        w = wedgeInfo.returnWedgeVolume(v.size_x(), v.size_y(), v.size_z(), False)
+        w = wedgeInfo.return_wedge_volume(v.size_x(), v.size_y(), v.size_z(), False)
         wrot = rotateWeighting( weighting=w, z1=rot[0], z2=rot[1], x=rot[2], mask=None,
                                 isReducedComplex=None,returnReducedComplex=True)
         fvol4 = complexRealMult(fv,wrot)

--- a/tests/test_FilterTest.py
+++ b/tests/test_FilterTest.py
@@ -38,7 +38,7 @@ class pytom_FilterTest(unittest.TestCase):
         from pytom.lib.pytom_volume import vol, rotate, complexRealMult
         from pytom.basic.structures import Wedge, Rotation
         from pytom.basic.fourier import fft, ifft
-        from pytom.basic.filter import rotateWeighting
+        from pytom.basic.filter import rotate_weighting
 
         dim = 24
         cent = int(dim/2)
@@ -65,7 +65,7 @@ class pytom_FilterTest(unittest.TestCase):
         #vfil3.write('xxx3.em')
 
         w = wedgeInfo.return_wedge_volume(v.size_x(), v.size_y(), v.size_z(), False)
-        wrot = rotateWeighting( weighting=w, z1=rot[0], z2=rot[1], x=rot[2], mask=None,
+        wrot = rotate_weighting( weighting=w, z1=rot[0], z2=rot[1], x=rot[2], mask=None,
                                 isReducedComplex=None,returnReducedComplex=True)
         fvol4 = complexRealMult(fv,wrot)
         vfil4 = ifft(fvol4)

--- a/tests/test_FilterTest.py
+++ b/tests/test_FilterTest.py
@@ -213,7 +213,7 @@ class pytom_FilterTest(unittest.TestCase):
 
     def test_profile(self):
         """test filter by 1-d profile"""
-        from pytom.basic.filter import profile2FourierVol
+        from pytom.basic.filter import profile_to_fourier_vol
         from pytom.basic.fourier import convolute, powerspectrum
         from pytom.lib.pytom_volume import vol
         from math import sqrt
@@ -222,7 +222,7 @@ class pytom_FilterTest(unittest.TestCase):
         profile = vol(16,1,1)
         for ii in range(0,16):
             profile.setV(ii, ii, 0, 0)
-        kernel = profile2FourierVol( profile=profile, dim=None, reduced=False)
+        kernel = profile_to_fourier_vol( profile=profile, dim=None, reduced=False)
         
         # point 
         volume = vol(32,32,32)

--- a/tests/test_NumpyTest.py
+++ b/tests/test_NumpyTest.py
@@ -39,14 +39,14 @@ class pytom_NumpyTest(unittest.TestCase):
         dtype = np.float32
 
         # no issues
-        temp = w.returnWedgeVolume(sx, sy, sz)
+        temp = w.return_wedge_volume(sx, sy, sz)
         wedge_pytom = pytom_numpy.vol2npy(temp).copy().astype(dtype)
         wedge_numpy = create_wedge(w1, w2, sx // 2, sx, sy, sz, smooth).astype(dtype)
         self.assertTrue((wedge_pytom != wedge_numpy).sum() == 0, msg='somehting is very wrong with conversion')
 
         # here there is an issue
         # this is just a known location where I know there is a mismatch of 8 (McHaillet)
-        wedge_pytom = pytom_numpy.vol2npy(w.returnWedgeVolume(sx, sy, sz)).copy().astype(dtype)
+        wedge_pytom = pytom_numpy.vol2npy(w.return_wedge_volume(sx, sy, sz)).copy().astype(dtype)
         wedge_numpy = create_wedge(w1, w2, sx // 2, sx, sy, sz, smooth).astype(dtype)
         print('These two arrays are not identical due to some issue with conversion between numpy and pytom volumes. '
               'There difference is: ', (wedge_pytom != wedge_numpy).sum())

--- a/tests/test_ScoreTest.py
+++ b/tests/test_ScoreTest.py
@@ -19,7 +19,7 @@ class pytom_ScoreTest(unittest.TestCase):
         # cleaner implementation would be multipliction with sqrt(mask) in corr function
         initSphere(self.mask,13,0,0,16,16,16)
         self.wi = WedgeInfo(wedge_angle=self.wedge, rotation=[10.0,20.0,30.0], 
-              cutoffRadius=0.0)
+              cutoff_radius=0.0)
         self.s = simpleSimulation( volume=self.v, rotation=self.rotation, 
               shiftV=self.shift, wedgeInfo=self.wi, SNR=10.)
 

--- a/tests/test_WedgeTest.py
+++ b/tests/test_WedgeTest.py
@@ -26,9 +26,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # here there is no problem
         SX, SY, SZ = self.SX, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -36,9 +36,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven X
         SX, SY, SZ = self.SX_uneven, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -46,9 +46,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven Y
         SX, SY, SZ = self.SX, self.SY_uneven, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -57,9 +57,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven Z
         SX, SY, SZ = self.SX, self.SY, self.SZ_uneven
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -78,9 +78,9 @@ class pytom_NumpyTest(unittest.TestCase):
             import matplotlib.pyplot as plt
 
             SX, SY, SZ = self.SX_uneven, self.SY, self.SZ
-            temp = w.returnWedgeVolume(SX, SY, SZ)
+            temp = w.return_wedge_volume(SX, SY, SZ)
             wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-            wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+            wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
             fig, ax = plt.subplots(1, 3)
             ax[0].imshow(wedge_numpy[:, 0, :])
             ax[0].set_title('agnostic wedge')
@@ -91,9 +91,9 @@ class pytom_NumpyTest(unittest.TestCase):
             plt.show()
 
             SX, SY, SZ = self.SX, self.SY, self.SZ_uneven
-            temp = w.returnWedgeVolume(SX, SY, SZ)
+            temp = w.return_wedge_volume(SX, SY, SZ)
             wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-            wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+            wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
             fig, ax = plt.subplots(1, 3)
             ax[0].imshow(wedge_numpy[:, 0, :])
             ax[0].set_title('agnostic wedge')
@@ -109,9 +109,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # here there is no problem
         SX, SY, SZ = self.SX, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ, humanUnderstandable=True)
+        temp = w.return_wedge_volume(SX, SY, SZ, humanUnderstandable=True)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, humanUnderstandable=True)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, humanUnderstandable=True)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -120,9 +120,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven X
         SX, SY, SZ = self.SX_uneven, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ, humanUnderstandable=True)
+        temp = w.return_wedge_volume(SX, SY, SZ, humanUnderstandable=True)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, humanUnderstandable=True)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, humanUnderstandable=True)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -131,9 +131,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven Y
         SX, SY, SZ = self.SX, self.SY_uneven, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ, humanUnderstandable=True)
+        temp = w.return_wedge_volume(SX, SY, SZ, humanUnderstandable=True)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, humanUnderstandable=True)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, humanUnderstandable=True)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -145,9 +145,9 @@ class pytom_NumpyTest(unittest.TestCase):
         w_np = w.convert2numpy()
 
         SX, SY, SZ = self.SX, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -156,9 +156,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven X
         SX, SY, SZ = self.SX_uneven, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -167,9 +167,9 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven Y
         SX, SY, SZ = self.SX, self.SY_uneven, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ)
+        temp = w.return_wedge_volume(SX, SY, SZ)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ)
         # cast from cupy to numpy if required
         if hasattr(wedge_numpy, 'get'):
             wedge_numpy = wedge_numpy.get()
@@ -189,9 +189,9 @@ class pytom_NumpyTest(unittest.TestCase):
         w_np = w.convert2numpy()
 
         SX, SY, SZ = self.SX, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+        temp = w.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
         # write('wedge_pytom.mrc', np.fft.ifftshift(wedge_pytom, axes=(0, 1)))
         # write('wedge_numpy.mrc', np.fft.ifftshift(wedge_numpy, axes=(0, 1)))
         print(nxcc(wedge_pytom, wedge_numpy))
@@ -199,17 +199,17 @@ class pytom_NumpyTest(unittest.TestCase):
 
         # test uneven X
         SX, SY, SZ = self.SX_uneven, self.SY, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+        temp = w.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
         print(nxcc(wedge_pytom, wedge_numpy))
         self.assertTrue(nxcc(wedge_pytom, wedge_numpy) > 0.90, "failing with uneven X")
 
         # test uneven Y
         SX, SY, SZ = self.SX, self.SY_uneven, self.SZ
-        temp = w.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+        temp = w.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
         wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-        wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+        wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
         print(nxcc(wedge_pytom, wedge_numpy))
         self.assertTrue(nxcc(wedge_pytom, wedge_numpy) > 0.90, "failing with uneven Y")
 
@@ -225,9 +225,9 @@ class pytom_NumpyTest(unittest.TestCase):
             import matplotlib.pyplot as plt
 
             SX, SY, SZ = self.SX, self.SY, self.SZ
-            temp = w.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+            temp = w.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
             wedge_pytom = vol2npy(temp).copy().astype(np.float32)
-            wedge_numpy = w_np.returnWedgeVolume(SX, SY, SZ, rotation=self.rotation)
+            wedge_numpy = w_np.return_wedge_volume(SX, SY, SZ, rotation=self.rotation)
             fig, ax = plt.subplots(1, 3)
             ax[0].imshow(wedge_numpy[:, 0, :])
             ax[0].set_title('agnostic wedge')


### PR DESCRIPTION
like #148 (redo of #157)

At the end of this PR for the file `pytom/agnostic/filter.py` should:
- `mypy --strict` only complain about "implicit reexport" (more info [here](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport))
- `ruff check --select E,F,PL,N,RUF,NPY,I ` only complain about `PLR2004` (too strict in my opinion), and `PLR0913`/`PLR0912` (require big refactors (outside of the scope of this PR)), more info on the codes can be found [here](https://beta.ruff.rs/docs/rules/)
- `black` has been run on the file

For the whole state of the repo:
- `pytom -m unittest discover` has no errors from the `test` directory and `E2E` tests 